### PR TITLE
feat: Import specific built-in elements for standalone components

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State />
+          <State>
+            <id>Pug/Jade</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>User defined</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/vscode-angular-auto-import.iml" filepath="$PROJECT_DIR$/.idea/vscode-angular-auto-import.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/vscode-angular-auto-import.iml
+++ b/.idea/vscode-angular-auto-import.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts = true

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from '@vscode/test-cli';
+
+export default defineConfig({
+	files: 'out/test/**/*.test.js',
+});

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["dbaeumer.vscode-eslint", "connor4312.esbuild-problem-matchers", "ms-vscode.extension-test-runner"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false, // set this to true to hide the "out" folder with the compiled JS files
+        "dist": false // set this to true to hide the "dist" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true, // set this to false to include "out" folder in search results
+        "dist": true // set this to false to include "dist" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,64 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+            "label": "watch",
+            "dependsOn": [
+                "npm: watch:tsc",
+                "npm: watch:esbuild"
+            ],
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "npm",
+            "script": "watch:esbuild",
+            "group": "build",
+            "problemMatcher": "$esbuild-watch",
+            "isBackground": true,
+            "label": "npm: watch:esbuild",
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            }
+        },
+		{
+            "type": "npm",
+            "script": "watch:tsc",
+            "group": "build",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "label": "npm: watch:tsc",
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            }
+        },
+		{
+			"type": "npm",
+			"script": "watch-tests",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never",
+				"group": "watchers"
+			},
+			"group": "build"
+		},
+		{
+			"label": "tasks: watch-tests",
+			"dependsOn": [
+				"npm: watch",
+				"npm: watch-tests"
+			],
+			"problemMatcher": []
+		}
+	]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,14 @@
+.vscode/**
+.vscode-test/**
+out/**
+node_modules/**
+src/**
+.gitignore
+.yarnrc
+esbuild.js
+vsc-extension-quickstart.md
+**/tsconfig.json
+**/eslint.config.mjs
+**/*.map
+**/*.ts
+**/.vscode-test.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "angular-auto-import" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # vscode-angular-auto-import
 Automatically suggests and inserts missing Angular component imports based on selectors used in templates.
+
+✨ Supports standalone components  
+🧠 Uses TypeScript AST and Angular selector detection  
+🔧 One-click fixes via VSCode Quick Fix  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # vscode-angular-auto-import
 Automatically suggests and inserts missing Angular component imports based on selectors used in templates.
 
-✨ Supports standalone components  
-🧠 Uses TypeScript AST and Angular selector detection  
-🔧 One-click fixes via VSCode Quick Fix  
+## Features
+
+*   **Automatic Import Suggestions:** Detects unimported Angular components, directives, and pipes used in your HTML templates.
+*   **One-Click Quick Fixes:** Provides VS Code Quick Fix actions (lightbulb icon) to insert missing imports directly.
+*   **Standalone Component Support:** Works seamlessly with Angular's standalone components, directives, and pipes.
+*   **AST-Based Detection:** Utilizes TypeScript's Abstract Syntax Tree (AST) for accurate element detection.
+
+### Third-Party Library Support
+
+Angular Auto Import now extends its capabilities to your project's dependencies! It automatically:
+
+*   Scans installed third-party Angular libraries (from your `package.json` dependencies in `node_modules`).
+*   Suggests components, directives, and pipes exported by these libraries.
+*   Generates correct import statements for these elements (e.g., `import { LibComponent } from 'my-lib';`).
+
+This helps you quickly integrate elements from your favorite Angular libraries without manually writing import statements.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Angular Auto Import now extends its capabilities to your project's dependencies!
 *   Generates correct import statements for these elements (e.g., `import { LibComponent } from 'my-lib';`).
 
 This helps you quickly integrate elements from your favorite Angular libraries without manually writing import statements.
+
+### Standalone Built-in Element Imports
+
+For modern Angular standalone components, the extension now helps you import precisely what you need:
+
+*   **Specific Imports:** Get suggestions and quick fixes for individual built-in directives (like `NgIf`, `NgForOf`, `NgOptimizedImage`) and pipes (like `AsyncPipe`, `DatePipe`) directly from their Angular framework packages (e.g., `@angular/common`).
+*   **Automatic `@Component.imports` Update:** When you accept a suggestion, the chosen directive or pipe is automatically added to your standalone component's `imports` array, making it immediately available in your template.
+*   **Best Practices:** This encourages fine-grained dependencies, aligning with Angular's standalone component philosophy, rather than always importing larger modules like `CommonModule` just for these common elements.

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,56 +1,74 @@
 const esbuild = require("esbuild");
 
-const production = process.argv.includes('--production');
-const watch = process.argv.includes('--watch');
+const production = process.argv.includes("--production");
+const watch = process.argv.includes("--watch");
 
 /**
- * @type {import('esbuild').Plugin}
+ * @type {import("esbuild").Plugin}
  */
 const esbuildProblemMatcherPlugin = {
-	name: 'esbuild-problem-matcher',
-
+	name: "esbuild-problem-matcher",
 	setup(build) {
 		build.onStart(() => {
-			console.log('[watch] build started');
+			console.log("[watch] build started");
 		});
 		build.onEnd((result) => {
-			result.errors.forEach(({ text, location }) => {
-				console.error(`✘ [ERROR] ${text}`);
-				console.error(`    ${location.file}:${location.line}:${location.column}:`);
-			});
-			console.log('[watch] build finished');
+			if (result.errors.length > 0) {
+				for (const { text, location } of result.errors) {
+					if (location) {
+						console.error(`✘ [ERROR] ${text}`);
+						console.error(`    ${location.file}:${location.line}:${location.column}`);
+					} else {
+						console.error(`✘ [ERROR] ${text}`);
+					}
+				}
+			}
+			if (result.warnings.length > 0) {
+				for (const { text, location } of result.warnings) {
+					if (location) {
+						console.warn(`⚠ [WARN] ${text}`);
+						console.warn(`    ${location.file}:${location.line}:${location.column}`);
+					} else {
+						console.warn(`⚠ [WARN] ${text}`);
+					}
+				}
+			}
+			console.log("[watch] build finished");
 		});
 	},
 };
 
 async function main() {
 	const ctx = await esbuild.context({
-		entryPoints: [
-			'src/extension.ts'
-		],
+		entryPoints: ["src/extension.ts"],
 		bundle: true,
-		format: 'cjs',
+		format: "cjs",
 		minify: production,
 		sourcemap: !production,
 		sourcesContent: false,
-		platform: 'node',
-		outfile: 'dist/extension.js',
-		external: ['vscode'],
-		logLevel: 'silent',
-		plugins: [
-			/* add to the end of plugins array */
-			esbuildProblemMatcherPlugin,
+		platform: "node",
+		target: "node22", // или твоя версия Node
+		outfile: "dist/extension.js",
+		logLevel: "silent",
+		external: [
+			"vscode",
+			"tree-sitter", // если используется
+			"tree-sitter-typescript",
+			"*.node", // это важно!
 		],
+		plugins: [esbuildProblemMatcherPlugin],
 	});
+
 	if (watch) {
 		await ctx.watch();
+		console.log("[watch] watching for changes...");
 	} else {
 		await ctx.rebuild();
 		await ctx.dispose();
 	}
 }
 
-main().catch(e => {
+main().catch((e) => {
 	console.error(e);
 	process.exit(1);
 });

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,0 +1,56 @@
+const esbuild = require("esbuild");
+
+const production = process.argv.includes('--production');
+const watch = process.argv.includes('--watch');
+
+/**
+ * @type {import('esbuild').Plugin}
+ */
+const esbuildProblemMatcherPlugin = {
+	name: 'esbuild-problem-matcher',
+
+	setup(build) {
+		build.onStart(() => {
+			console.log('[watch] build started');
+		});
+		build.onEnd((result) => {
+			result.errors.forEach(({ text, location }) => {
+				console.error(`✘ [ERROR] ${text}`);
+				console.error(`    ${location.file}:${location.line}:${location.column}:`);
+			});
+			console.log('[watch] build finished');
+		});
+	},
+};
+
+async function main() {
+	const ctx = await esbuild.context({
+		entryPoints: [
+			'src/extension.ts'
+		],
+		bundle: true,
+		format: 'cjs',
+		minify: production,
+		sourcemap: !production,
+		sourcesContent: false,
+		platform: 'node',
+		outfile: 'dist/extension.js',
+		external: ['vscode'],
+		logLevel: 'silent',
+		plugins: [
+			/* add to the end of plugins array */
+			esbuildProblemMatcherPlugin,
+		],
+	});
+	if (watch) {
+		await ctx.watch();
+	} else {
+		await ctx.rebuild();
+		await ctx.dispose();
+	}
+}
+
+main().catch(e => {
+	console.error(e);
+	process.exit(1);
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,28 @@
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+export default [{
+    files: ["**/*.ts"],
+}, {
+    plugins: {
+        "@typescript-eslint": typescriptEslint,
+    },
+
+    languageOptions: {
+        parser: tsParser,
+        ecmaVersion: 2022,
+        sourceType: "module",
+    },
+
+    rules: {
+        "@typescript-eslint/naming-convention": ["warn", {
+            selector: "import",
+            format: ["camelCase", "PascalCase"],
+        }],
+
+        curly: "warn",
+        eqeqeq: "warn",
+        "no-throw-literal": "warn",
+        semi: "warn",
+    },
+}];

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "angular-auto-import.helloWorld",
-        "title": "Hello World"
+        "command": "angular-auto-import.Reindex",
+        "title": "Reindex"
       }
     ]
   },
@@ -34,16 +34,20 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.100.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@types/vscode": "^1.100.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
-    "eslint": "^9.25.1",
-    "esbuild": "^0.25.3",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^5.8.3",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^2.5.2",
+    "esbuild": "^0.25.3",
+    "eslint": "^9.25.1",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "tree-sitter": "^0.22.4",
+    "tree-sitter-typescript": "^0.23.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "angular-auto-import",
+  "displayName": "Angular auto import",
+  "description": "Automatically suggests and inserts missing Angular component imports based on selectors used in templates.",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.100.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "angular-auto-import.helloWorld",
+        "title": "Hello World"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "pnpm run package",
+    "compile": "pnpm run check-types && pnpm run lint && node esbuild.js",
+    "watch": "npm-run-all -p watch:*",
+    "watch:esbuild": "node esbuild.js --watch",
+    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+    "package": "pnpm run check-types && pnpm run lint && node esbuild.js --production",
+    "compile-tests": "tsc -p . --outDir out",
+    "watch-tests": "tsc -p . -w --outDir out",
+    "pretest": "pnpm run compile-tests && pnpm run compile && pnpm run lint",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src",
+    "test": "vscode-test"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.100.0",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "20.x",
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
+    "eslint": "^9.25.1",
+    "esbuild": "^0.25.3",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.8.3",
+    "@vscode/test-cli": "^0.0.10",
+    "@vscode/test-electron": "^2.5.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "contributes": {
     "commands": [
       {
-        "command": "angular-auto-import.Reindex",
+        "command": "angular-auto-import.reindex",
         "title": "Reindex"
       }
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      tree-sitter:
+        specifier: ^0.22.4
+        version: 0.22.4
+      tree-sitter-typescript:
+        specifier: ^0.23.2
+        version: 0.23.2(tree-sitter@0.22.4)
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10
@@ -1137,6 +1144,14 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
+  node-addon-api@8.3.1:
+    resolution: {integrity: sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
@@ -1485,6 +1500,25 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter@0.22.4:
+    resolution: {integrity: sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2798,6 +2832,10 @@ snapshots:
 
   nice-try@1.0.5: {}
 
+  node-addon-api@8.3.1: {}
+
+  node-gyp-build@4.8.4: {}
+
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -3194,6 +3232,26 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tree-sitter-javascript@0.23.1(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.3.1
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter-typescript@0.23.2(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.3.1
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1(tree-sitter@0.22.4)
+    optionalDependencies:
+      tree-sitter: 0.22.4
+
+  tree-sitter@0.22.4:
+    dependencies:
+      node-addon-api: 8.3.1
+      node-gyp-build: 4.8.4
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,3367 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: 20.x
+        version: 20.17.50
+      '@types/vscode':
+        specifier: ^1.100.0
+        version: 1.100.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.31.1
+        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.8.3))(eslint@9.27.0)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.31.1
+        version: 8.32.1(eslint@9.27.0)(typescript@5.8.3)
+      '@vscode/test-cli':
+        specifier: ^0.0.10
+        version: 0.0.10
+      '@vscode/test-electron':
+        specifier: ^2.5.2
+        version: 2.5.2
+      esbuild:
+        specifier: ^0.25.3
+        version: 0.25.4
+      eslint:
+        specifier: ^9.25.1
+        version: 9.27.0
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.20.0':
+    resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.2.2':
+    resolution: {integrity: sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.14.0':
+    resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.27.0':
+    resolution: {integrity: sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.1':
+    resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
+
+  '@types/node@20.17.50':
+    resolution: {integrity: sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==}
+
+  '@types/vscode@1.100.0':
+    resolution: {integrity: sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==}
+
+  '@typescript-eslint/eslint-plugin@8.32.1':
+    resolution: {integrity: sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.32.1':
+    resolution: {integrity: sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/scope-manager@8.32.1':
+    resolution: {integrity: sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/type-utils@8.32.1':
+    resolution: {integrity: sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/types@8.32.1':
+    resolution: {integrity: sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.32.1':
+    resolution: {integrity: sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.32.1':
+    resolution: {integrity: sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    resolution: {integrity: sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vscode/test-cli@0.0.10':
+    resolution: {integrity: sha512-B0mMH4ia+MOOtwNiLi79XhA+MLmUItIC8FckEuKrVAVriIuSWjt7vv4+bF8qVFiNFe4QRfzPaIZk39FZGWEwHA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@vscode/test-electron@2.5.2':
+    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
+    engines: {node: '>=16'}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  c8@9.1.0:
+    resolution: {integrity: sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==}
+    engines: {node: '>=14.14.0'}
+    hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.4.1:
+    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@10.4.0:
+    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+    engines: {node: '>=10.13.0'}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-abstract@1.23.10:
+    resolution: {integrity: sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.3.0:
+    resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.27.0:
+    resolution: {integrity: sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.3.0:
+    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.3.0:
+    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
+    engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.4:
+    resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
+    engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-better-errors@1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  load-json-file@4.0.0:
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mocha@10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
+    engines: {node: '>= 14.0.0'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-all@4.1.5:
+    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
+    engines: {node: '>= 4'}
+    hasBin: true
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-type@3.0.0:
+    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
+    engines: {node: '>=4'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  pidtree@0.3.1:
+    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  read-pkg@3.0.0:
+    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
+    engines: {node: '>=4'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shell-quote@1.8.2:
+    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.21:
+    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string.prototype.padend@3.1.6:
+    resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tapable@2.2.2:
+    resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
+    engines: {node: '>=6'}
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@esbuild/aix-ppc64@0.25.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/android-arm@0.25.4':
+    optional: true
+
+  '@esbuild/android-x64@0.25.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.4':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.27.0)':
+    dependencies:
+      eslint: 9.27.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.20.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.1(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.2.2': {}
+
+  '@eslint/core@0.14.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1(supports-color@8.1.1)
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.27.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.1':
+    dependencies:
+      '@eslint/core': 0.14.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@types/estree@1.0.7': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/mocha@10.0.10': {}
+
+  '@types/node@20.17.50':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/vscode@1.100.0': {}
+
+  '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.8.3))(eslint@9.27.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.32.1(eslint@9.27.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/type-utils': 8.32.1(eslint@9.27.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.32.1(eslint@9.27.0)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.1
+      eslint: 9.27.0
+      graphemer: 1.4.0
+      ignore: 7.0.4
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.1
+      debug: 4.4.1(supports-color@8.1.1)
+      eslint: 9.27.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
+
+  '@typescript-eslint/type-utils@8.32.1(eslint@9.27.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.32.1(eslint@9.27.0)(typescript@5.8.3)
+      debug: 4.4.1(supports-color@8.1.1)
+      eslint: 9.27.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.32.1': {}
+
+  '@typescript-eslint/typescript-estree@8.32.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
+      debug: 4.4.1(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.32.1(eslint@9.27.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.27.0)
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.8.3)
+      eslint: 9.27.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      eslint-visitor-keys: 4.2.0
+
+  '@vscode/test-cli@0.0.10':
+    dependencies:
+      '@types/mocha': 10.0.10
+      c8: 9.1.0
+      chokidar: 3.6.0
+      enhanced-resolve: 5.18.1
+      glob: 10.4.5
+      minimatch: 9.0.5
+      mocha: 10.8.2
+      supports-color: 9.4.0
+      yargs: 17.7.2
+
+  '@vscode/test-electron@2.5.2':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jszip: 3.10.1
+      ora: 8.2.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  acorn-jsx@5.3.2(acorn@8.14.1):
+    dependencies:
+      acorn: 8.14.1
+
+  acorn@8.14.1: {}
+
+  agent-base@7.1.3: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  argparse@2.0.1: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.10
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  async-function@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  balanced-match@1.0.2: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
+
+  c8@9.1.0:
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.1.7
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  camelcase@6.3.0: {}
+
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.4.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.3: {}
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.3: {}
+
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  debug@4.4.1(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
+
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  diff@5.2.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@10.4.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  enhanced-resolve@5.18.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.2
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-abstract@1.23.10:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.19
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.3.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.0: {}
+
+  eslint@9.27.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.27.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.20.0
+      '@eslint/config-helpers': 0.2.2
+      '@eslint/core': 0.14.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.27.0
+      '@eslint/plugin-kit': 0.3.1
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.3.0:
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 4.2.0
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flat@5.0.2: {}
+
+  flatted@3.3.3: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.3.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+
+  globals@14.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  graphemer@1.4.0: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@3.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  he@1.2.0: {}
+
+  hosted-git-info@2.8.9: {}
+
+  html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.4: {}
+
+  immediate@3.0.6: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-interactive@2.0.0: {}
+
+  is-map@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.19
+
+  is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-parse-better-errors@1.0.2: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  load-json-file@4.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 4.0.0
+      pify: 3.0.0
+      strip-bom: 3.0.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.4.1
+      is-unicode-supported: 1.3.0
+
+  lru-cache@10.4.3: {}
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  math-intrinsics@1.1.0: {}
+
+  memorystream@0.3.1: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  mimic-function@5.0.1: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.11
+
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minipass@7.1.2: {}
+
+  mocha@10.8.2:
+    dependencies:
+      ansi-colors: 4.1.3
+      browser-stdout: 1.3.1
+      chokidar: 3.6.0
+      debug: 4.4.1(supports-color@8.1.1)
+      diff: 5.2.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 8.1.0
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 5.1.6
+      ms: 2.1.3
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 6.5.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  nice-try@1.0.5: {}
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-path@3.0.0: {}
+
+  npm-run-all@4.1.5:
+    dependencies:
+      ansi-styles: 3.2.1
+      chalk: 2.4.2
+      cross-spawn: 6.0.6
+      memorystream: 0.3.1
+      minimatch: 3.1.2
+      pidtree: 0.3.1
+      read-pkg: 3.0.0
+      shell-quote: 1.8.2
+      string.prototype.padend: 3.1.6
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.4.1
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  pako@1.0.11: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@4.0.0:
+    dependencies:
+      error-ex: 1.3.2
+      json-parse-better-errors: 1.0.2
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@2.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  path-type@3.0.0:
+    dependencies:
+      pify: 3.0.0
+
+  picomatch@2.3.1: {}
+
+  pidtree@0.3.1: {}
+
+  pify@3.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
+
+  prelude-ls@1.2.1: {}
+
+  process-nextick-args@2.0.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  read-pkg@3.0.0:
+    dependencies:
+      load-json-file: 4.0.0
+      normalize-package-data: 2.5.0
+      path-type: 3.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.10
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  require-directory@2.1.1: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  semver@5.7.2: {}
+
+  semver@7.7.2: {}
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
+
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@1.0.0: {}
+
+  shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.2: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  signal-exit@4.1.0: {}
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.21
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.21
+
+  spdx-license-ids@3.0.21: {}
+
+  stdin-discarder@0.2.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.4.0
+      get-east-asian-width: 1.3.0
+      strip-ansi: 7.1.0
+
+  string.prototype.padend@3.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.10
+      es-object-atoms: 1.1.1
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.10
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
+
+  strip-bom@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@9.4.0: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tapable@2.2.2: {}
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.1.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typescript@5.8.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
+  undici-types@6.19.8: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.0
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  workerpool@6.5.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  wrappy@1.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}

--- a/src/angular-builtins.ts
+++ b/src/angular-builtins.ts
@@ -1,0 +1,59 @@
+// Defines a list of common built-in Angular directives and pipes
+// that are often used as standalone imports in components.
+
+interface BuiltInAngularElement {
+  className: string;
+  sourcePackage: string;
+  type: 'directive' | 'pipe';
+  templateMatcher?: RegExp; // To match how it's used in templates for QuickFix
+}
+
+export const BUILTIN_ANGULAR_ELEMENTS_MAP: Record<string, BuiltInAngularElement> = {
+  // Common Directives from @angular/common
+  'NgIf': { className: 'NgIf', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /\*ngIf|ngIf/i },
+  'NgForOf': { className: 'NgForOf', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /\*ngFor|ngFor|ngForOf/i }, // ngForOf for property binding
+  'NgClass': { className: 'NgClass', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngClass/i },
+  'NgStyle': { className: 'NgStyle', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngStyle/i },
+  'NgSwitch': { className: 'NgSwitch', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngSwitch/i },
+  'NgSwitchCase': { className: 'NgSwitchCase', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngSwitchCase/i },
+  'NgSwitchDefault': { className: 'NgSwitchDefault', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngSwitchDefault/i },
+  'NgTemplateOutlet': { className: 'NgTemplateOutlet', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngTemplateOutlet/i },
+  'NgComponentOutlet': { className: 'NgComponentOutlet', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /ngComponentOutlet/i },
+  'NgOptimizedImage': { className: 'NgOptimizedImage', sourcePackage: '@angular/common', type: 'directive', templateMatcher: /NgOptimizedImage|ngSrc/i }, // ngSrc is an attribute
+
+  // Common Pipes from @angular/common
+  'AsyncPipe': { className: 'AsyncPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /async/i },
+  'CurrencyPipe': { className: 'CurrencyPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /currency/i },
+  'DatePipe': { className: 'DatePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /date/i },
+  'DecimalPipe': { className: 'DecimalPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /number/i }, // 'number' is the pipe alias
+  'I18nPluralPipe': { className: 'I18nPluralPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /i18nPlural/i },
+  'I18nSelectPipe': { className: 'I18nSelectPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /i18nSelect/i },
+  'JsonPipe': { className: 'JsonPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /json/i },
+  'KeyValuePipe': { className: 'KeyValuePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /keyvalue/i },
+  'LowerCasePipe': { className: 'LowerCasePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /lowercase/i },
+  'PercentPipe': { className: 'PercentPipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /percent/i },
+  'SlicePipe': { className: 'SlicePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /slice/i },
+  'UpperCasePipe': { className: 'UpperCasePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /uppercase/i },
+  'TitleCasePipe': { className: 'TitleCasePipe', sourcePackage: '@angular/common', type: 'pipe', templateMatcher: /titlecase/i },
+} as const;
+
+
+// This can be used by providers to iterate and match
+export const BUILTIN_ANGULAR_ELEMENT_LIST: readonly BuiltInAngularElement[] = Object.values(BUILTIN_ANGULAR_ELEMENTS_MAP);
+
+// Example usage for QuickFix:
+// User writes `*ngIf="condition"`, diagnostic identifies `*ngIf`.
+// Search `BUILTIN_ANGULAR_ELEMENT_LIST` where `templateMatcher` matches `*ngIf`.
+// Found: `NgIf` element.
+// Check if component is standalone. If yes, offer to import `NgIf` from `@angular/common`.
+
+// Example usage for Completion:
+// User types `*ngI` in a standalone component template.
+// Filter `BUILTIN_ANGULAR_ELEMENT_LIST` for directives. `NgIf` matches.
+// Offer completion for `*ngIf`. On accept, import `NgIf` from `@angular/common`.
+// User types `value | asy`
+// Filter `BUILTIN_ANGULAR_ELEMENT_LIST` for pipes. `AsyncPipe` matches.
+// Offer completion for `async`. On accept, import `AsyncPipe` from `@angular/common`.
+
+// Renamed from BUILTIN_ANGULAR_STANDALONE_ELEMENTS to BUILTIN_ANGULAR_ELEMENTS_MAP for clarity
+// and added BUILTIN_ANGULAR_ELEMENT_LIST for easier iteration.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,26 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+import * as vscode from 'vscode';
+
+// This method is called when your extension is activated
+// Your extension is activated the very first time the command is executed
+export function activate(context: vscode.ExtensionContext) {
+
+	// Use the console to output diagnostic information (console.log) and errors (console.error)
+	// This line of code will only be executed once when your extension is activated
+	console.log('Congratulations, your extension "angular-auto-import" is now active!');
+
+	// The command has been defined in the package.json file
+	// Now provide the implementation of the command with registerCommand
+	// The commandId parameter must match the command field in package.json
+	const disposable = vscode.commands.registerCommand('angular-auto-import.helloWorld', () => {
+		// The code you place here will be executed every time your command is executed
+		// Display a message box to the user
+		vscode.window.showInformationMessage('Hello World from Angular auto import!');
+	});
+
+	context.subscriptions.push(disposable); 
+}
+
+// This method is called when your extension is deactivated
+export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,682 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { CompletionItem } from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+// Tree-sitter imports
+import Parser from 'tree-sitter';
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "angular-auto-import" is now active!');
+const TypeScript = require('tree-sitter-typescript').typescript;
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('angular-auto-import.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from Angular auto import!');
-	});
-
-	context.subscriptions.push(disposable); 
+interface ComponentInfo {
+  path: string;
+  componentName: string;
+  selector: string;
+  lastModified: number;
+  hash: string;
 }
 
-// This method is called when your extension is deactivated
-export function deactivate() {}
+class ComponentData {
+  path: string;
+  componentName: string;
+
+  constructor(path: string, componentName: string) {
+    this.path = path;
+    this.componentName = componentName;
+  }
+}
+
+// Enhanced caching and indexing
+class ComponentIndexer {
+  private parser: any;
+  private fileCache: Map<string, ComponentInfo> = new Map();
+  private selectorToComponent: Map<string, ComponentData> = new Map();
+  private fileWatcher: vscode.FileSystemWatcher | null = null;
+
+  constructor() {
+    this.parser = new Parser();
+    this.parser.setLanguage(TypeScript);
+  }
+
+  /**
+   * Initialize file watcher for incremental updates
+   */
+  initializeWatcher(context: vscode.ExtensionContext, projectPath: string) {
+    // Clean up existing watcher
+    if (this.fileWatcher) {
+      this.fileWatcher.dispose();
+    }
+
+    // Watch for component file changes
+    const pattern = new vscode.RelativePattern(projectPath, '**/*.component.ts');
+    this.fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    this.fileWatcher.onDidCreate((uri) => {
+      console.log(`File created: ${uri.fsPath}`);
+      this.updateFileIndex(uri.fsPath, projectPath, context);
+    });
+
+    this.fileWatcher.onDidChange((uri) => {
+      console.log(`File changed: ${uri.fsPath}`);
+      this.updateFileIndex(uri.fsPath, projectPath, context);
+    });
+
+    this.fileWatcher.onDidDelete((uri) => {
+      console.log(`File deleted: ${uri.fsPath}`);
+      this.removeFromIndex(uri.fsPath, context);
+    });
+
+    context.subscriptions.push(this.fileWatcher);
+  }
+
+  /**
+   * Generate hash for file content to detect changes
+   */
+  private generateHash(content: string): string {
+    let hash = 0;
+    for (let i = 0; i < content.length; i++) {
+      const char = content.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return hash.toString();
+  }
+
+  /**
+   * Parse component using Tree-sitter
+   */
+  private parseComponentWithTreeSitter(filePath: string, content: string): { selector?: string; componentName?: string } | null {
+    try {
+      const tree = this.parser.parse(content);
+      const rootNode = tree.rootNode;
+
+      let selector: string | undefined;
+      let componentName: string | undefined;
+
+      // Query for @Component decorator
+      const componentQuery = `
+        (decorator
+          (call_expression
+            function: (identifier) @decorator_name
+            arguments: (arguments
+              (object
+                (property_assignment
+                  name: (property_identifier) @prop_name
+                  value: (string) @prop_value
+                )*
+              )
+            )
+          )
+        )
+        (#eq? @decorator_name "Component")
+      `;
+
+      // Query for class export
+      const classQuery = `
+        (export_statement
+          (class_declaration
+            name: (identifier) @class_name
+          )
+        )
+      `;
+
+      // Find selector in @Component decorator
+      this.traverseNode(rootNode, (node) => {
+        if (node.type === 'decorator') {
+          const decoratorNode = node.children.find((child: any) => child.type === 'call_expression');
+          if (decoratorNode) {
+            const functionNode = decoratorNode.children.find((child: any) => child.type === 'identifier');
+            if (functionNode && content.slice(functionNode.startIndex, functionNode.endIndex) === 'Component') {
+              // Found @Component decorator, now find selector
+              const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
+              if (argsNode) {
+                const objectNode = argsNode.children.find((child: any) => child.type === 'object');
+                if (objectNode) {
+                  this.traverseNode(objectNode, (propNode) => {
+                    if (propNode.type === 'property_assignment') {
+                      const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
+                      const valueNode = propNode.children.find((child: any) => child.type === 'string');
+                      
+                      if (nameNode && valueNode) {
+                        const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
+                        if (propName === 'selector') {
+                          const selectorValue = content.slice(valueNode.startIndex, valueNode.endIndex);
+                          selector = selectorValue.slice(1, -1); // Remove quotes
+                        }
+                      }
+                    }
+                  });
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Find exported class name
+      this.traverseNode(rootNode, (node) => {
+        if (node.type === 'export_statement') {
+          const classNode = node.children.find((child: any) => child.type === 'class_declaration');
+          if (classNode) {
+            const nameNode = classNode.children.find((child: any) => child.type === 'identifier');
+            if (nameNode) {
+              componentName = content.slice(nameNode.startIndex, nameNode.endIndex);
+            }
+          }
+        }
+      });
+
+      return selector && componentName ? { selector, componentName } : null;
+    } catch (error) {
+      console.error(`Tree-sitter parsing error for ${filePath}:`, error);
+      return this.parseComponentWithRegex(content); // Fallback to regex
+    }
+  }
+
+  /**
+   * Fallback regex parsing (original method)
+   */
+  private parseComponentWithRegex(content: string): { selector?: string; componentName?: string } | null {
+    const selectorRegex = /selector: '([^(?<!\\)']*)',/;
+    const componentNameRegex = /export class ([\S]*)/;
+
+    const selectorMatch = selectorRegex.exec(content);
+    const componentNameMatch = componentNameRegex.exec(content);
+
+    if (selectorMatch?.[1] && componentNameMatch?.[1]) {
+      return {
+        selector: selectorMatch[1],
+        componentName: componentNameMatch[1]
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Traverse Tree-sitter node recursively
+   */
+  private traverseNode(node: any, callback: (node: any) => void) {
+    callback(node);
+    for (let i = 0; i < node.childCount; i++) {
+      this.traverseNode(node.child(i), callback);
+    }
+  }
+
+  /**
+   * Update index for a single file
+   */
+  private async updateFileIndex(filePath: string, projectPath: string, context: vscode.ExtensionContext): Promise<void> {
+    try {
+      const stats = fs.statSync(filePath);
+      const lastModified = stats.mtime.getTime();
+      const relativePath = path.relative(projectPath, filePath);
+
+      // Check if file needs reprocessing
+      const cached = this.fileCache.get(filePath);
+      if (cached && cached.lastModified >= lastModified) {
+        return; // File hasn't changed
+      }
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const hash = this.generateHash(content);
+
+      // Check content hash to avoid reprocessing identical content
+      if (cached && cached.hash === hash) {
+        return;
+      }
+
+      // Parse component using Tree-sitter
+      const parsed = this.parseComponentWithTreeSitter(filePath, content);
+      
+      if (parsed && parsed.selector && parsed.componentName) {
+        // Remove old selector mapping if exists
+        if (cached) {
+          this.selectorToComponent.delete(cached.selector);
+        }
+
+        // Add new mapping
+        const componentInfo: ComponentInfo = {
+          path: relativePath,
+          componentName: parsed.componentName,
+          selector: parsed.selector,
+          lastModified,
+          hash
+        };
+
+        this.fileCache.set(filePath, componentInfo);
+        this.selectorToComponent.set(parsed.selector, new ComponentData(relativePath, parsed.componentName));
+
+        console.log(`Updated index for: ${relativePath} -> ${parsed.selector}`);
+      } else {
+        // Remove from cache if parsing failed
+        if (cached) {
+          this.fileCache.delete(filePath);
+          this.selectorToComponent.delete(cached.selector);
+        }
+      }
+
+      // Persist to workspace state
+      await this.saveIndexToWorkspace(context);
+
+    } catch (error) {
+      console.error(`Error updating index for ${filePath}:`, error);
+    }
+  }
+
+  /**
+   * Remove file from index
+   */
+  private async removeFromIndex(filePath: string, context: vscode.ExtensionContext): Promise<void> {
+    const cached = this.fileCache.get(filePath);
+    if (cached) {
+      this.fileCache.delete(filePath);
+      this.selectorToComponent.delete(cached.selector);
+      await this.saveIndexToWorkspace(context);
+      console.log(`Removed from index: ${filePath}`);
+    }
+  }
+
+  /**
+   * Initial full index generation
+   */
+  async generateFullIndex(projectPath: string, context: vscode.ExtensionContext): Promise<Map<string, ComponentData>> {
+    console.log('INDEXING with Tree-sitter...');
+    
+    const componentFiles = this.getTypescriptFiles(projectPath);
+    const tasks: Promise<void>[] = [];
+
+    // Process files in parallel batches to avoid overwhelming the system
+    const batchSize = 10;
+    for (let i = 0; i < componentFiles.length; i += batchSize) {
+      const batch = componentFiles.slice(i, i + batchSize);
+      const batchTasks = batch.map(file => 
+        this.updateFileIndex(path.join(projectPath, file), projectPath, context)
+      );
+      tasks.push(...batchTasks);
+      
+      // Wait for batch to complete before starting next batch
+      await Promise.all(batchTasks);
+    }
+
+    console.log(`Indexed ${this.selectorToComponent.size} components using Tree-sitter`);
+    return this.selectorToComponent;
+  }
+
+  /**
+   * Load index from workspace state
+   */
+  loadFromWorkspace(context: vscode.ExtensionContext): boolean {
+    try {
+      const storedCache = context.workspaceState.get('componentFileCache') as Map<string, ComponentInfo>;
+      const storedIndex = context.workspaceState.get('componentSelectorToDataIndex') as Map<string, ComponentData>;
+
+      if (storedCache && storedIndex) {
+        this.fileCache = new Map(Object.entries(storedCache));
+        this.selectorToComponent = new Map(Object.entries(storedIndex));
+        console.log(`Loaded ${this.selectorToComponent.size} components from cache`);
+        return true;
+      }
+    } catch (error) {
+      console.error('Error loading index from workspace:', error);
+    }
+    return false;
+  }
+
+  /**
+   * Save index to workspace state
+   */
+  private async saveIndexToWorkspace(context: vscode.ExtensionContext): Promise<void> {
+    try {
+      await context.workspaceState.update('componentFileCache', Object.fromEntries(this.fileCache));
+      await context.workspaceState.update('componentSelectorToDataIndex', Object.fromEntries(this.selectorToComponent));
+    } catch (error) {
+      console.error('Error saving index to workspace:', error);
+    }
+  }
+
+  /**
+   * Get component by selector
+   */
+  getComponent(selector: string): ComponentData | undefined {
+    return this.selectorToComponent.get(selector);
+  }
+
+  /**
+   * Get all selectors
+   */
+  getAllSelectors(): IterableIterator<string> {
+    return this.selectorToComponent.keys();
+  }
+
+  /**
+   * Get typescript component files (unchanged from original)
+   */
+  private getTypescriptFiles(filePath: string): string[] {
+    const tsFiles: string[] = [];
+
+    const isGitIgnored = (fileName: string, gitIgnorePath: string): boolean => {
+      if (!fs.existsSync(gitIgnorePath)) return false;
+
+      const gitIgnoreContent = fs.readFileSync(gitIgnorePath, 'utf-8');
+      const gitIgnorePatterns = gitIgnoreContent.split('\n').filter(Boolean);
+
+      return gitIgnorePatterns.some((pattern) => {
+        const regexp = new RegExp(pattern.replace(/\*/g, '.*'));
+        return regexp.test(fileName);
+      });
+    };
+
+    const traverseDirectory = (dirPath: string, gitIgnorePath?: string) => {
+      const files = fs.readdirSync(dirPath);
+
+      files.forEach((file) => {
+        const fullPath = path.join(dirPath, file);
+        const relativePath = path.relative(filePath, fullPath);
+
+        if (gitIgnorePath && isGitIgnored(relativePath, gitIgnorePath)) {
+          return;
+        }
+
+        if (fs.statSync(fullPath).isDirectory()) {
+          traverseDirectory(fullPath, gitIgnorePath);
+        } else if (file.endsWith('component.ts')) {
+          tsFiles.push(relativePath);
+        }
+      });
+    };
+
+    if (fs.existsSync(filePath)) {
+      const stats = fs.statSync(filePath);
+      if (stats.isDirectory()) {
+        const gitIgnorePath = path.join(filePath, '.gitignore');
+        traverseDirectory(filePath, gitIgnorePath);
+      } else if (filePath.endsWith('component.ts')) {
+        tsFiles.push(path.basename(filePath));
+      }
+    }
+    console.log(`Found ${tsFiles.length} component files.`);
+    return tsFiles;
+  }
+
+  dispose() {
+    if (this.fileWatcher) {
+      this.fileWatcher.dispose();
+    }
+  }
+}
+
+// State
+let componentIndexer: ComponentIndexer;
+let interval: any;
+
+// Config
+let reindexInterval: number = 60;
+let projectPath: string | undefined;
+
+function getConfiguration() { 
+  const config = vscode.workspace.getConfiguration('angular-auto-import');
+  reindexInterval = config.get('angular-auto-import.index.refreshInterval') ?? 60;
+  return config;
+}
+
+function getRelativeFilePath(file1: string, file2: string): string {
+  return path.relative(path.dirname(file1), file2);
+}
+
+function importComponentToFile(component: ComponentData, filePath: string): boolean {
+  try {
+    let importStr: string;
+    importStr = `import { ${component.componentName} } from '${getRelativeFilePath(
+      filePath,
+      `${projectPath}/${switchFileType(component.path, '')}`
+    )}'\n`;
+    const fileContents = fs.readFileSync(filePath);
+    let newFileContents = importStr + fileContents.toString();
+    newFileContents = addImportToAnnotation(component, newFileContents);
+
+    fs.writeFileSync(filePath, newFileContents);
+    setTimeout(() => vscode.commands.executeCommand('editor.action.formatDocument', filePath), 0);
+
+    return true;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+}
+
+function addImportToAnnotation(component: ComponentData, fileContents: string) {
+  const importRegex = /(@Component\({[\s\S]*imports: \[(\s*))([^}]*}\))/;
+  if (importRegex.test(fileContents.toString())) {
+    const isImportsEmptyRegex = /(@Component\({[\s\S]*imports: \[(\s*)\])([^}]*}\))/;
+    let fileWithImport: string;
+    if (isImportsEmptyRegex.test(fileContents)) {
+      fileWithImport = fileContents.toString().replace(importRegex, `$1${component.componentName}$2$3`);
+    } else {
+      fileWithImport = fileContents.toString().replace(importRegex, `$1${component.componentName}, $2$3`);
+    }
+    return fileWithImport;
+  } else {
+    const componentRegex = /(@Component\({(\s*))/;
+    return fileContents.toString().replace(componentRegex, `$1imports: [${component.componentName}],$2`);
+  }
+}
+
+function switchFileType(filePath: string, newExtension: string): string {
+  const path = require('path');
+  const fileBaseName = path.basename(filePath, path.extname(filePath));
+  const fileDirectory = path.dirname(filePath);
+
+  let newFilePath;
+  if (!newExtension) {
+    newFilePath = path.join(fileDirectory, `${fileBaseName}`);
+  } else {
+    newFilePath = path.join(fileDirectory, `${fileBaseName}.${newExtension}`);
+  }
+
+  return newFilePath;
+}
+
+function importComponent(component?: ComponentData): boolean {
+  if (!component) {
+    console.error('Component not found. Please check that the provided selector is correct, reindex, and try again.');
+    vscode.window.showInformationMessage('Component not found. Please reindex and try again.');
+    return false;
+  }
+  const currentFile = vscode.window.activeTextEditor?.document.fileName;
+  if (!currentFile) {
+    return false;
+  }
+  const activeComponentFile = switchFileType(currentFile, 'ts');
+  const success = importComponentToFile(component, activeComponentFile);
+  if (!success) {
+    vscode.window.showInformationMessage('Something went wrong while importing your component. Please try again.');
+  }
+  return success;
+}
+
+async function setComponentDataIndex(context: vscode.ExtensionContext) {
+  if (!componentIndexer) {
+    componentIndexer = new ComponentIndexer();
+  }
+
+  // Try to load from cache first
+  if (componentIndexer.loadFromWorkspace(context)) {
+    return;
+  }
+
+  // If cache is empty, generate full index
+  await generateIndex(context);
+}
+
+async function generateIndex(context: vscode.ExtensionContext) {
+  const folderPath = getProjectPath();
+  if (!componentIndexer) {
+    componentIndexer = new ComponentIndexer();
+  }
+  
+  await componentIndexer.generateFullIndex(folderPath, context);
+  
+  // Initialize file watcher for incremental updates
+  componentIndexer.initializeWatcher(context, folderPath);
+}
+
+function getProjectPath(): string {
+  const config = getConfiguration();
+  projectPath = config.get('angular-auto-import.projectPath');
+  if (!projectPath) {
+    const workspace = vscode.workspace;
+    if (workspace.workspaceFolders) {
+      const firstFolder = workspace.workspaceFolders[0];
+      const folderUri = firstFolder.uri;
+      const folderPath = folderUri.fsPath;
+      projectPath = folderPath;
+    } else {
+      console.error('No active folder found.');
+    }
+  }
+  return projectPath ?? '';
+}
+
+export async function activate(activationContext: vscode.ExtensionContext) {
+  // Get config settings
+  getConfiguration();
+
+  // Set the index with optimized indexer
+  await setComponentDataIndex(activationContext);
+
+  // Register interval for periodic reindexing (optional, since we have file watchers)
+  if (!!interval) {
+    clearInterval(interval);
+  }
+  if (reindexInterval !== 0) {
+    interval = setInterval(async () => {
+      await generateIndex(activationContext);
+    }, Math.floor(reindexInterval) * 1000);
+  }
+
+  const reindexCommand = vscode.commands.registerCommand('angular-auto-import.reindex', async () => {
+    try {
+      await generateIndex(activationContext);
+      vscode.window.showInformationMessage('angular-auto-import: Reindex successful.');
+    } catch {
+      vscode.window.showInformationMessage('angular-auto-import: Something went wrong when reindexing. Some components may be missing.');
+    }
+  });
+  activationContext.subscriptions.push(reindexCommand);
+
+  // File creation handler (redundant now with file watcher, but keeping for compatibility)
+  activationContext.subscriptions.push(
+    vscode.workspace.onDidCreateFiles((event) => {
+      // File watcher will handle this automatically
+    })
+  );
+
+  // Register quick fix
+  activationContext.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider({ scheme: 'file', language: 'html' }, new QuickfixImportProvider(), {
+      providedCodeActionKinds: QuickfixImportProvider.providedCodeActionKinds,
+    })
+  );
+
+  // Register command to do component importing
+  const importCommand = vscode.commands.registerCommand('angular-auto-import.importComponent', (componentSelector: string) =>
+    importComponent(componentIndexer.getComponent(componentSelector))
+  );
+  activationContext.subscriptions.push(importCommand);
+
+  const manualImportCommand = vscode.commands.registerCommand('angular-auto-import.manual.importComponent', (componentSelector: string) => {
+    vscode.window
+      .showInputBox({
+        prompt: 'Enter your argument',
+        placeHolder: 'Type here...',
+        value: '',
+      })
+      .then((userInput) => {
+        const success = importComponent(componentIndexer.getComponent(userInput ?? ''));
+        if (success) {
+          vscode.window.showInformationMessage('Component imported successfully.');
+        }
+        return;
+      });
+  });
+
+  activationContext.subscriptions.push(manualImportCommand);
+
+  // Register autocompletion
+  activationContext.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      { scheme: 'file', language: 'html' },
+      {
+        provideCompletionItems(
+          document: vscode.TextDocument,
+          position: vscode.Position,
+          token: vscode.CancellationToken,
+          context: vscode.CompletionContext
+        ) {
+          const linePrefix = document.lineAt(position).text.slice(0, position.character);
+          const openMarkerRegex = /<([^\s>]*)$/;
+          const suggestions: CompletionItem[] = [];
+          const match = openMarkerRegex.exec(linePrefix);
+          
+          if (match && match[1]) {
+            const selectorInProgress = match[1];
+            for (const selector of componentIndexer.getAllSelectors()) {
+              if (selector.includes(selectorInProgress)) {
+                const component = componentIndexer.getComponent(selector);
+                const item = new CompletionItem(selector);
+                item.commitCharacters = ['>'];
+                item.documentation = `angular-auto-import: add and import ${component?.componentName} from ${component?.path}`;
+                item.command = { title: 'import component', command: 'angular-auto-import.importComponent', arguments: [selector] };
+                suggestions.push(item);
+              }
+            }
+          }
+
+          return suggestions;
+        },
+      }
+    )
+  );
+}
+
+export function deactivate() {
+  if (componentIndexer) {
+    componentIndexer.dispose();
+  }
+  if (interval) {
+    clearInterval(interval);
+  }
+}
+
+export class QuickfixImportProvider implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+  public static readonly fixesDiagnosticCode: number[] = [-998001];
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    context: vscode.CodeActionContext,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+    for (const diagnostic of context.diagnostics) {
+      if (diagnostic.code && typeof diagnostic.code === 'number' && QuickfixImportProvider.fixesDiagnosticCode.includes(diagnostic.code)) {
+        let selector = document.getText(diagnostic.range);
+        if (selector.startsWith('<') && selector.endsWith('>')) {
+          selector = selector.slice(1, selector.length - 1);
+          const component = componentIndexer.getComponent(selector);
+          if (component) {
+            const fix = new vscode.CodeAction(
+              `angular-auto-import: Import component ${component.componentName} from ${component.path}`,
+              vscode.CodeActionKind.QuickFix
+            );
+            fix.command = { title: 'import component', command: 'angular-auto-import.importComponent', arguments: [selector] };
+            fix.diagnostics = [diagnostic];
+            return [fix];
+          }
+        }
+      }
+    }
+    return [];
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,27 +10,30 @@ const TypeScript = require('tree-sitter-typescript').typescript;
 
 interface ComponentInfo {
   path: string;
-  componentName: string;
+  name: string;
   selector: string;
   lastModified: number;
   hash: string;
+  type: 'component' | 'directive' | 'pipe';
 }
 
-class ComponentData {
+class AngularElementData {
   path: string;
-  componentName: string;
+  name: string;
+  type: 'component' | 'directive' | 'pipe';
 
-  constructor(path: string, componentName: string) {
+  constructor(path: string, name: string, type: 'component' | 'directive' | 'pipe') {
     this.path = path;
-    this.componentName = componentName;
+    this.name = name;
+    this.type = type;
   }
 }
 
 // Enhanced caching and indexing
-class ComponentIndexer {
+class AngularIndexer {
   private parser: any;
   private fileCache: Map<string, ComponentInfo> = new Map();
-  private selectorToComponent: Map<string, ComponentData> = new Map();
+  private selectorToElement: Map<string, AngularElementData> = new Map();
   private fileWatcher: vscode.FileSystemWatcher | null = null;
 
   constructor() {
@@ -47,8 +50,8 @@ class ComponentIndexer {
       this.fileWatcher.dispose();
     }
 
-    // Watch for component file changes
-    const pattern = new vscode.RelativePattern(projectPath, '**/*.component.ts');
+    // Watch for Angular file changes (components, directives, pipes)
+    const pattern = new vscode.RelativePattern(projectPath, '**/*.{component,directive,pipe}.ts');
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
 
     this.fileWatcher.onDidCreate((uri) => {
@@ -83,70 +86,36 @@ class ComponentIndexer {
   }
 
   /**
-   * Parse component using Tree-sitter
+   * Parse Angular element using Tree-sitter
    */
-  private parseComponentWithTreeSitter(filePath: string, content: string): { selector?: string; componentName?: string } | null {
+  private parseAngularElementWithTreeSitter(filePath: string, content: string): ComponentInfo | null {
     try {
       const tree = this.parser.parse(content);
       const rootNode = tree.rootNode;
 
       let selector: string | undefined;
-      let componentName: string | undefined;
+      let elementName: string | undefined;
+      let elementType: 'component' | 'directive' | 'pipe' | undefined;
+      let pipeName: string | undefined;
 
-      // Query for @Component decorator
-      const componentQuery = `
-        (decorator
-          (call_expression
-            function: (identifier) @decorator_name
-            arguments: (arguments
-              (object
-                (property_assignment
-                  name: (property_identifier) @prop_name
-                  value: (string) @prop_value
-                )*
-              )
-            )
-          )
-        )
-        (#eq? @decorator_name "Component")
-      `;
-
-      // Query for class export
-      const classQuery = `
-        (export_statement
-          (class_declaration
-            name: (identifier) @class_name
-          )
-        )
-      `;
-
-      // Find selector in @Component decorator
+      // Find decorator and class export
       this.traverseNode(rootNode, (node) => {
         if (node.type === 'decorator') {
           const decoratorNode = node.children.find((child: any) => child.type === 'call_expression');
           if (decoratorNode) {
             const functionNode = decoratorNode.children.find((child: any) => child.type === 'identifier');
-            if (functionNode && content.slice(functionNode.startIndex, functionNode.endIndex) === 'Component') {
-              // Found @Component decorator, now find selector
-              const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
-              if (argsNode) {
-                const objectNode = argsNode.children.find((child: any) => child.type === 'object');
-                if (objectNode) {
-                  this.traverseNode(objectNode, (propNode) => {
-                    if (propNode.type === 'property_assignment') {
-                      const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
-                      const valueNode = propNode.children.find((child: any) => child.type === 'string');
-                      
-                      if (nameNode && valueNode) {
-                        const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
-                        if (propName === 'selector') {
-                          const selectorValue = content.slice(valueNode.startIndex, valueNode.endIndex);
-                          selector = selectorValue.slice(1, -1); // Remove quotes
-                        }
-                      }
-                    }
-                  });
-                }
+            if (functionNode) {
+              const decoratorName = content.slice(functionNode.startIndex, functionNode.endIndex);
+              
+              if (decoratorName === 'Component') {
+                elementType = 'component';
+                selector = this.extractSelectorFromDecorator(decoratorNode, content);
+              } else if (decoratorName === 'Directive') {
+                elementType = 'directive';
+                selector = this.extractSelectorFromDecorator(decoratorNode, content);
+              } else if (decoratorName === 'Pipe') {
+                elementType = 'pipe';
+                pipeName = this.extractPipeNameFromDecorator(decoratorNode, content);
               }
             }
           }
@@ -160,33 +129,134 @@ class ComponentIndexer {
           if (classNode) {
             const nameNode = classNode.children.find((child: any) => child.type === 'identifier');
             if (nameNode) {
-              componentName = content.slice(nameNode.startIndex, nameNode.endIndex);
+              elementName = content.slice(nameNode.startIndex, nameNode.endIndex);
             }
           }
         }
       });
 
-      return selector && componentName ? { selector, componentName } : null;
+      if (elementName && elementType) {
+        const finalSelector = elementType === 'pipe' ? pipeName : selector;
+        if (finalSelector) {
+          return {
+            path: path.relative(this.getProjectPath(), filePath),
+            name: elementName,
+            selector: finalSelector,
+            lastModified: fs.statSync(filePath).mtime.getTime(),
+            hash: this.generateHash(content),
+            type: elementType
+          };
+        }
+      }
+
+      return null;
     } catch (error) {
       console.error(`Tree-sitter parsing error for ${filePath}:`, error);
-      return this.parseComponentWithRegex(content); // Fallback to regex
+      return this.parseAngularElementWithRegex(filePath, content); // Fallback to regex
     }
   }
 
   /**
-   * Fallback regex parsing (original method)
+   * Extract selector from @Component or @Directive decorator
    */
-  private parseComponentWithRegex(content: string): { selector?: string; componentName?: string } | null {
-    const selectorRegex = /selector: '([^(?<!\\)']*)',/;
-    const componentNameRegex = /export class ([\S]*)/;
+  private extractSelectorFromDecorator(decoratorNode: any, content: string): string | undefined {
+    const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
+    if (argsNode) {
+      const objectNode = argsNode.children.find((child: any) => child.type === 'object');
+      if (objectNode) {
+        let selector: string | undefined;
+        this.traverseNode(objectNode, (propNode) => {
+          if (propNode.type === 'property_assignment') {
+            const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
+            const valueNode = propNode.children.find((child: any) => child.type === 'string');
+            
+            if (nameNode && valueNode) {
+              const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
+              if (propName === 'selector') {
+                const selectorValue = content.slice(valueNode.startIndex, valueNode.endIndex);
+                selector = selectorValue.slice(1, -1); // Remove quotes
+              }
+            }
+          }
+        });
+        return selector;
+      }
+    }
+    return undefined;
+  }
 
-    const selectorMatch = selectorRegex.exec(content);
-    const componentNameMatch = componentNameRegex.exec(content);
+  /**
+   * Extract name from @Pipe decorator
+   */
+  private extractPipeNameFromDecorator(decoratorNode: any, content: string): string | undefined {
+    const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
+    if (argsNode) {
+      const objectNode = argsNode.children.find((child: any) => child.type === 'object');
+      if (objectNode) {
+        let pipeName: string | undefined;
+        this.traverseNode(objectNode, (propNode) => {
+          if (propNode.type === 'property_assignment') {
+            const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
+            const valueNode = propNode.children.find((child: any) => child.type === 'string');
+            
+            if (nameNode && valueNode) {
+              const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
+              if (propName === 'name') {
+                const nameValue = content.slice(valueNode.startIndex, valueNode.endIndex);
+                pipeName = nameValue.slice(1, -1); // Remove quotes
+              }
+            }
+          }
+        });
+        return pipeName;
+      }
+    }
+    return undefined;
+  }
 
-    if (selectorMatch?.[1] && componentNameMatch?.[1]) {
+  /**
+   * Fallback regex parsing
+   */
+  private parseAngularElementWithRegex(filePath: string, content: string): ComponentInfo | null {
+    const selectorRegex = /selector:\s*['"]([^'"]*)['"]/;
+    const pipeNameRegex = /name:\s*['"]([^'"]*)['"]/;
+    const classNameRegex = /export\s+class\s+(\w+)/;
+
+    const fileName = path.basename(filePath);
+    let elementType: 'component' | 'directive' | 'pipe';
+    
+    if (fileName.includes('.component.')) {
+      elementType = 'component';
+    } else if (fileName.includes('.directive.')) {
+      elementType = 'directive';
+    } else if (fileName.includes('.pipe.')) {
+      elementType = 'pipe';
+    } else {
+      return null;
+    }
+
+    const classNameMatch = classNameRegex.exec(content);
+    if (!classNameMatch?.[1]) {
+      return null;
+    }
+
+    let selector: string | undefined;
+    if (elementType === 'pipe') {
+      const pipeNameMatch = pipeNameRegex.exec(content);
+      selector = pipeNameMatch?.[1];
+    } else {
+      const selectorMatch = selectorRegex.exec(content);
+      selector = selectorMatch?.[1];
+    }
+
+    if (selector) {
       return {
-        selector: selectorMatch[1],
-        componentName: componentNameMatch[1]
+        path: path.relative(this.getProjectPath(), filePath),
+        name: classNameMatch[1],
+        selector,
+        lastModified: fs.statSync(filePath).mtime.getTime(),
+        hash: this.generateHash(content),
+        type: elementType
       };
     }
 
@@ -208,9 +278,12 @@ class ComponentIndexer {
    */
   private async updateFileIndex(filePath: string, projectPath: string, context: vscode.ExtensionContext): Promise<void> {
     try {
+      if (!fs.existsSync(filePath)) {
+        return;
+      }
+
       const stats = fs.statSync(filePath);
       const lastModified = stats.mtime.getTime();
-      const relativePath = path.relative(projectPath, filePath);
 
       // Check if file needs reprocessing
       const cached = this.fileCache.get(filePath);
@@ -226,33 +299,24 @@ class ComponentIndexer {
         return;
       }
 
-      // Parse component using Tree-sitter
-      const parsed = this.parseComponentWithTreeSitter(filePath, content);
+      // Parse Angular element using Tree-sitter
+      const parsed = this.parseAngularElementWithTreeSitter(filePath, content);
       
-      if (parsed && parsed.selector && parsed.componentName) {
+      if (parsed) {
         // Remove old selector mapping if exists
         if (cached) {
-          this.selectorToComponent.delete(cached.selector);
+          this.selectorToElement.delete(cached.selector);
         }
 
-        // Add new mapping
-        const componentInfo: ComponentInfo = {
-          path: relativePath,
-          componentName: parsed.componentName,
-          selector: parsed.selector,
-          lastModified,
-          hash
-        };
+        this.fileCache.set(filePath, parsed);
+        this.selectorToElement.set(parsed.selector, new AngularElementData(parsed.path, parsed.name, parsed.type));
 
-        this.fileCache.set(filePath, componentInfo);
-        this.selectorToComponent.set(parsed.selector, new ComponentData(relativePath, parsed.componentName));
-
-        console.log(`Updated index for: ${relativePath} -> ${parsed.selector}`);
+        console.log(`Updated index for: ${parsed.path} -> ${parsed.selector} (${parsed.type})`);
       } else {
         // Remove from cache if parsing failed
         if (cached) {
           this.fileCache.delete(filePath);
-          this.selectorToComponent.delete(cached.selector);
+          this.selectorToElement.delete(cached.selector);
         }
       }
 
@@ -271,7 +335,7 @@ class ComponentIndexer {
     const cached = this.fileCache.get(filePath);
     if (cached) {
       this.fileCache.delete(filePath);
-      this.selectorToComponent.delete(cached.selector);
+      this.selectorToElement.delete(cached.selector);
       await this.saveIndexToWorkspace(context);
       console.log(`Removed from index: ${filePath}`);
     }
@@ -280,27 +344,25 @@ class ComponentIndexer {
   /**
    * Initial full index generation
    */
-  async generateFullIndex(projectPath: string, context: vscode.ExtensionContext): Promise<Map<string, ComponentData>> {
-    console.log('INDEXING with Tree-sitter...');
+  async generateFullIndex(projectPath: string, context: vscode.ExtensionContext): Promise<Map<string, AngularElementData>> {
+    console.log('INDEXING Angular elements with Tree-sitter...');
     
-    const componentFiles = this.getTypescriptFiles(projectPath);
-    const tasks: Promise<void>[] = [];
-
+    const angularFiles = this.getAngularFiles(projectPath);
+    
     // Process files in parallel batches to avoid overwhelming the system
     const batchSize = 10;
-    for (let i = 0; i < componentFiles.length; i += batchSize) {
-      const batch = componentFiles.slice(i, i + batchSize);
+    for (let i = 0; i < angularFiles.length; i += batchSize) {
+      const batch = angularFiles.slice(i, i + batchSize);
       const batchTasks = batch.map(file => 
         this.updateFileIndex(path.join(projectPath, file), projectPath, context)
       );
-      tasks.push(...batchTasks);
       
       // Wait for batch to complete before starting next batch
       await Promise.all(batchTasks);
     }
 
-    console.log(`Indexed ${this.selectorToComponent.size} components using Tree-sitter`);
-    return this.selectorToComponent;
+    console.log(`Indexed ${this.selectorToElement.size} Angular elements using Tree-sitter`);
+    return this.selectorToElement;
   }
 
   /**
@@ -308,13 +370,17 @@ class ComponentIndexer {
    */
   loadFromWorkspace(context: vscode.ExtensionContext): boolean {
     try {
-      const storedCache = context.workspaceState.get('componentFileCache') as Map<string, ComponentInfo>;
-      const storedIndex = context.workspaceState.get('componentSelectorToDataIndex') as Map<string, ComponentData>;
+      const storedCache = context.workspaceState.get('angularFileCache');
+      const storedIndex = context.workspaceState.get('angularSelectorToDataIndex');
 
       if (storedCache && storedIndex) {
-        this.fileCache = new Map(Object.entries(storedCache));
-        this.selectorToComponent = new Map(Object.entries(storedIndex));
-        console.log(`Loaded ${this.selectorToComponent.size} components from cache`);
+        // Convert plain objects back to Maps
+        this.fileCache = new Map(Object.entries(storedCache as Record<string, ComponentInfo>));
+        this.selectorToElement = new Map(Object.entries(storedIndex as Record<string, AngularElementData>).map(([key, value]) => [
+          key,
+          new AngularElementData(value.path, value.name, value.type)
+        ]));
+        console.log(`Loaded ${this.selectorToElement.size} Angular elements from cache`);
         return true;
       }
     } catch (error) {
@@ -328,75 +394,105 @@ class ComponentIndexer {
    */
   private async saveIndexToWorkspace(context: vscode.ExtensionContext): Promise<void> {
     try {
-      await context.workspaceState.update('componentFileCache', Object.fromEntries(this.fileCache));
-      await context.workspaceState.update('componentSelectorToDataIndex', Object.fromEntries(this.selectorToComponent));
+      await context.workspaceState.update('angularFileCache', Object.fromEntries(this.fileCache));
+      await context.workspaceState.update('angularSelectorToDataIndex', Object.fromEntries(this.selectorToElement));
     } catch (error) {
       console.error('Error saving index to workspace:', error);
     }
   }
 
   /**
-   * Get component by selector
+   * Get Angular element by selector
    */
-  getComponent(selector: string): ComponentData | undefined {
-    return this.selectorToComponent.get(selector);
+  getElement(selector: string): AngularElementData | undefined {
+    return this.selectorToElement.get(selector);
   }
 
   /**
    * Get all selectors
    */
   getAllSelectors(): IterableIterator<string> {
-    return this.selectorToComponent.keys();
+    return this.selectorToElement.keys();
   }
 
   /**
-   * Get typescript component files (unchanged from original)
+   * Get Angular files (components, directives, pipes)
    */
-  private getTypescriptFiles(filePath: string): string[] {
-    const tsFiles: string[] = [];
+  private getAngularFiles(filePath: string): string[] {
+    const angularFiles: string[] = [];
 
     const isGitIgnored = (fileName: string, gitIgnorePath: string): boolean => {
       if (!fs.existsSync(gitIgnorePath)) return false;
 
-      const gitIgnoreContent = fs.readFileSync(gitIgnorePath, 'utf-8');
-      const gitIgnorePatterns = gitIgnoreContent.split('\n').filter(Boolean);
+      try {
+        const gitIgnoreContent = fs.readFileSync(gitIgnorePath, 'utf-8');
+        const gitIgnorePatterns = gitIgnoreContent.split('\n')
+          .map(line => line.trim())
+          .filter(line => line && !line.startsWith('#'));
 
-      return gitIgnorePatterns.some((pattern) => {
-        const regexp = new RegExp(pattern.replace(/\*/g, '.*'));
-        return regexp.test(fileName);
-      });
+        return gitIgnorePatterns.some((pattern) => {
+          try {
+            const regexp = new RegExp(pattern.replace(/\*/g, '.*').replace(/\?/g, '.'));
+            return regexp.test(fileName);
+          } catch {
+            return false;
+          }
+        });
+      } catch {
+        return false;
+      }
     };
 
     const traverseDirectory = (dirPath: string, gitIgnorePath?: string) => {
-      const files = fs.readdirSync(dirPath);
+      try {
+        const files = fs.readdirSync(dirPath);
 
-      files.forEach((file) => {
-        const fullPath = path.join(dirPath, file);
-        const relativePath = path.relative(filePath, fullPath);
+        files.forEach((file) => {
+          const fullPath = path.join(dirPath, file);
+          const relativePath = path.relative(filePath, fullPath);
 
-        if (gitIgnorePath && isGitIgnored(relativePath, gitIgnorePath)) {
-          return;
-        }
+          if (gitIgnorePath && isGitIgnored(relativePath, gitIgnorePath)) {
+            return;
+          }
 
-        if (fs.statSync(fullPath).isDirectory()) {
-          traverseDirectory(fullPath, gitIgnorePath);
-        } else if (file.endsWith('component.ts')) {
-          tsFiles.push(relativePath);
-        }
-      });
+          try {
+            if (fs.statSync(fullPath).isDirectory()) {
+              // Skip node_modules and other common directories
+              if (!['node_modules', '.git', 'dist', 'build'].includes(file)) {
+                traverseDirectory(fullPath, gitIgnorePath);
+              }
+            } else if (file.match(/\.(component|directive|pipe)\.ts$/)) {
+              angularFiles.push(relativePath);
+            }
+          } catch (error) {
+            console.warn(`Error processing file ${fullPath}:`, error);
+          }
+        });
+      } catch (error) {
+        console.warn(`Error reading directory ${dirPath}:`, error);
+      }
     };
 
     if (fs.existsSync(filePath)) {
-      const stats = fs.statSync(filePath);
-      if (stats.isDirectory()) {
-        const gitIgnorePath = path.join(filePath, '.gitignore');
-        traverseDirectory(filePath, gitIgnorePath);
-      } else if (filePath.endsWith('component.ts')) {
-        tsFiles.push(path.basename(filePath));
+      try {
+        const stats = fs.statSync(filePath);
+        if (stats.isDirectory()) {
+          const gitIgnorePath = path.join(filePath, '.gitignore');
+          traverseDirectory(filePath, gitIgnorePath);
+        } else if (filePath.match(/\.(component|directive|pipe)\.ts$/)) {
+          angularFiles.push(path.basename(filePath));
+        }
+      } catch (error) {
+        console.error(`Error processing path ${filePath}:`, error);
       }
     }
-    console.log(`Found ${tsFiles.length} component files.`);
-    return tsFiles;
+    
+    console.log(`Found ${angularFiles.length} Angular files.`);
+    return angularFiles;
+  }
+
+  private getProjectPath(): string {
+    return projectPath ?? '';
   }
 
   dispose() {
@@ -407,7 +503,7 @@ class ComponentIndexer {
 }
 
 // State
-let componentIndexer: ComponentIndexer;
+let angularIndexer: AngularIndexer;
 let interval: any;
 
 // Config
@@ -424,84 +520,99 @@ function getRelativeFilePath(file1: string, file2: string): string {
   return path.relative(path.dirname(file1), file2);
 }
 
-function importComponentToFile(component: ComponentData, filePath: string): boolean {
+function importElementToFile(element: AngularElementData, filePath: string): boolean {
   try {
-    let importStr: string;
-    importStr = `import { ${component.componentName} } from '${getRelativeFilePath(
-      filePath,
-      `${projectPath}/${switchFileType(component.path, '')}`
-    )}'\n`;
-    const fileContents = fs.readFileSync(filePath);
-    let newFileContents = importStr + fileContents.toString();
-    newFileContents = addImportToAnnotation(component, newFileContents);
+    const relativePath = getRelativeFilePath(filePath, `${projectPath}/${switchFileType(element.path, '')}`);
+    let importStr = `import { ${element.name} } from '${relativePath.startsWith('.') ? relativePath : './' + relativePath}';\n`;
+    
+    const fileContents = fs.readFileSync(filePath, 'utf-8');
+    
+    // Check if import already exists
+    const importRegex = new RegExp(`import\\s*{[^}]*\\b${element.name}\\b[^}]*}\\s*from\\s*['"][^'"]*['"]`, 'g');
+    if (importRegex.test(fileContents)) {
+      console.log(`${element.name} is already imported`);
+      return true;
+    }
+
+    let newFileContents = importStr + fileContents;
+    newFileContents = addImportToAnnotation(element, newFileContents);
 
     fs.writeFileSync(filePath, newFileContents);
-    setTimeout(() => vscode.commands.executeCommand('editor.action.formatDocument', filePath), 0);
+    
+    // Format document after a short delay
+    setTimeout(() => {
+      vscode.commands.executeCommand('editor.action.formatDocument') // .catch(console.error);
+    }, 100);
 
     return true;
   } catch (e) {
-    console.error(e);
+    console.error('Error importing element:', e);
     return false;
   }
 }
 
-function addImportToAnnotation(component: ComponentData, fileContents: string) {
-  const importRegex = /(@Component\({[\s\S]*imports: \[(\s*))([^}]*}\))/;
-  if (importRegex.test(fileContents.toString())) {
-    const isImportsEmptyRegex = /(@Component\({[\s\S]*imports: \[(\s*)\])([^}]*}\))/;
-    let fileWithImport: string;
-    if (isImportsEmptyRegex.test(fileContents)) {
-      fileWithImport = fileContents.toString().replace(importRegex, `$1${component.componentName}$2$3`);
-    } else {
-      fileWithImport = fileContents.toString().replace(importRegex, `$1${component.componentName}, $2$3`);
-    }
-    return fileWithImport;
+function addImportToAnnotation(element: AngularElementData, fileContents: string): string {
+  const importRegex = /(@Component\({[\s\S]*?imports:\s*\[)([^\]]*?)(\][\s\S]*?}\))/;
+  
+  if (importRegex.test(fileContents)) {
+    return fileContents.replace(importRegex, (match, before, imports, after) => {
+      const trimmedImports = imports.trim();
+      if (trimmedImports === '') {
+        return `${before}${element.name}${after}`;
+      } else {
+        return `${before}${trimmedImports}, ${element.name}${after}`;
+      }
+    });
   } else {
-    const componentRegex = /(@Component\({(\s*))/;
-    return fileContents.toString().replace(componentRegex, `$1imports: [${component.componentName}],$2`);
+    // Add imports array to @Component decorator
+    const componentRegex = /(@Component\({)(\s*)/;
+    return fileContents.replace(componentRegex, `$1$2imports: [${element.name}],$2`);
   }
 }
 
 function switchFileType(filePath: string, newExtension: string): string {
-  const path = require('path');
   const fileBaseName = path.basename(filePath, path.extname(filePath));
   const fileDirectory = path.dirname(filePath);
 
-  let newFilePath;
   if (!newExtension) {
-    newFilePath = path.join(fileDirectory, `${fileBaseName}`);
+    return path.join(fileDirectory, fileBaseName);
   } else {
-    newFilePath = path.join(fileDirectory, `${fileBaseName}.${newExtension}`);
+    return path.join(fileDirectory, `${fileBaseName}.${newExtension}`);
   }
-
-  return newFilePath;
 }
 
-function importComponent(component?: ComponentData): boolean {
-  if (!component) {
-    console.error('Component not found. Please check that the provided selector is correct, reindex, and try again.');
-    vscode.window.showInformationMessage('Component not found. Please reindex and try again.');
+function importElement(element?: AngularElementData): boolean {
+  if (!element) {
+    console.error('Angular element not found. Please check that the provided selector is correct, reindex, and try again.');
+    vscode.window.showInformationMessage('Angular element not found. Please reindex and try again.');
     return false;
   }
+  
   const currentFile = vscode.window.activeTextEditor?.document.fileName;
   if (!currentFile) {
+    vscode.window.showErrorMessage('No active file found.');
     return false;
   }
+  
   const activeComponentFile = switchFileType(currentFile, 'ts');
-  const success = importComponentToFile(component, activeComponentFile);
+  const success = importElementToFile(element, activeComponentFile);
+  
   if (!success) {
-    vscode.window.showInformationMessage('Something went wrong while importing your component. Please try again.');
+    vscode.window.showInformationMessage(`Something went wrong while importing your ${element.type}. Please try again.`);
+  } else {
+    vscode.window.showInformationMessage(`${element.type} ${element.name} imported successfully.`);
   }
+  
   return success;
 }
 
-async function setComponentDataIndex(context: vscode.ExtensionContext) {
-  if (!componentIndexer) {
-    componentIndexer = new ComponentIndexer();
+async function setAngularDataIndex(context: vscode.ExtensionContext) {
+  if (!angularIndexer) {
+    angularIndexer = new AngularIndexer();
   }
 
   // Try to load from cache first
-  if (componentIndexer.loadFromWorkspace(context)) {
+  if (angularIndexer.loadFromWorkspace(context)) {
     return;
   }
 
@@ -511,138 +622,177 @@ async function setComponentDataIndex(context: vscode.ExtensionContext) {
 
 async function generateIndex(context: vscode.ExtensionContext) {
   const folderPath = getProjectPath();
-  if (!componentIndexer) {
-    componentIndexer = new ComponentIndexer();
+  if (!angularIndexer) {
+    angularIndexer = new AngularIndexer();
   }
   
-  await componentIndexer.generateFullIndex(folderPath, context);
+  await angularIndexer.generateFullIndex(folderPath, context);
   
   // Initialize file watcher for incremental updates
-  componentIndexer.initializeWatcher(context, folderPath);
+  angularIndexer.initializeWatcher(context, folderPath);
 }
 
 function getProjectPath(): string {
   const config = getConfiguration();
   projectPath = config.get('angular-auto-import.projectPath');
+  
   if (!projectPath) {
     const workspace = vscode.workspace;
-    if (workspace.workspaceFolders) {
+    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
       const firstFolder = workspace.workspaceFolders[0];
-      const folderUri = firstFolder.uri;
-      const folderPath = folderUri.fsPath;
-      projectPath = folderPath;
+      projectPath = firstFolder.uri.fsPath;
     } else {
       console.error('No active folder found.');
+      throw new Error('No workspace folder found');
     }
   }
-  return projectPath ?? '';
+  
+  return projectPath;
 }
 
 export async function activate(activationContext: vscode.ExtensionContext) {
-  // Get config settings
-  getConfiguration();
+  try {
+    // Get config settings
+    getConfiguration();
 
-  // Set the index with optimized indexer
-  await setComponentDataIndex(activationContext);
+    // Set the index with optimized indexer
+    await setAngularDataIndex(activationContext);
 
-  // Register interval for periodic reindexing (optional, since we have file watchers)
-  if (!!interval) {
-    clearInterval(interval);
-  }
-  if (reindexInterval !== 0) {
-    interval = setInterval(async () => {
-      await generateIndex(activationContext);
-    }, Math.floor(reindexInterval) * 1000);
-  }
-
-  const reindexCommand = vscode.commands.registerCommand('angular-auto-import.reindex', async () => {
-    try {
-      await generateIndex(activationContext);
-      vscode.window.showInformationMessage('angular-auto-import: Reindex successful.');
-    } catch {
-      vscode.window.showInformationMessage('angular-auto-import: Something went wrong when reindexing. Some components may be missing.');
+    // Register interval for periodic reindexing (optional, since we have file watchers)
+    if (interval) {
+      clearInterval(interval);
     }
-  });
-  activationContext.subscriptions.push(reindexCommand);
-
-  // File creation handler (redundant now with file watcher, but keeping for compatibility)
-  activationContext.subscriptions.push(
-    vscode.workspace.onDidCreateFiles((event) => {
-      // File watcher will handle this automatically
-    })
-  );
-
-  // Register quick fix
-  activationContext.subscriptions.push(
-    vscode.languages.registerCodeActionsProvider({ scheme: 'file', language: 'html' }, new QuickfixImportProvider(), {
-      providedCodeActionKinds: QuickfixImportProvider.providedCodeActionKinds,
-    })
-  );
-
-  // Register command to do component importing
-  const importCommand = vscode.commands.registerCommand('angular-auto-import.importComponent', (componentSelector: string) =>
-    importComponent(componentIndexer.getComponent(componentSelector))
-  );
-  activationContext.subscriptions.push(importCommand);
-
-  const manualImportCommand = vscode.commands.registerCommand('angular-auto-import.manual.importComponent', (componentSelector: string) => {
-    vscode.window
-      .showInputBox({
-        prompt: 'Enter your argument',
-        placeHolder: 'Type here...',
-        value: '',
-      })
-      .then((userInput) => {
-        const success = importComponent(componentIndexer.getComponent(userInput ?? ''));
-        if (success) {
-          vscode.window.showInformationMessage('Component imported successfully.');
+    
+    if (reindexInterval !== 0) {
+      interval = setInterval(async () => {
+        try {
+          await generateIndex(activationContext);
+        } catch (error) {
+          console.error('Error during periodic reindexing:', error);
         }
-        return;
-      });
-  });
+      }, Math.floor(reindexInterval) * 1000);
+    }
 
-  activationContext.subscriptions.push(manualImportCommand);
+    // Register reindex command
+    const reindexCommand = vscode.commands.registerCommand('angular-auto-import.reindex', async () => {
+      try {
+        await generateIndex(activationContext);
+        vscode.window.showInformationMessage('angular-auto-import: Reindex successful.');
+      } catch (error) {
+        console.error('Reindex error:', error);
+        vscode.window.showInformationMessage('angular-auto-import: Something went wrong when reindexing. Some elements may be missing.');
+      }
+    });
+    activationContext.subscriptions.push(reindexCommand);
 
-  // Register autocompletion
-  activationContext.subscriptions.push(
-    vscode.languages.registerCompletionItemProvider(
-      { scheme: 'file', language: 'html' },
-      {
-        provideCompletionItems(
-          document: vscode.TextDocument,
-          position: vscode.Position,
-          token: vscode.CancellationToken,
-          context: vscode.CompletionContext
-        ) {
-          const linePrefix = document.lineAt(position).text.slice(0, position.character);
-          const openMarkerRegex = /<([^\s>]*)$/;
-          const suggestions: CompletionItem[] = [];
-          const match = openMarkerRegex.exec(linePrefix);
-          
-          if (match && match[1]) {
-            const selectorInProgress = match[1];
-            for (const selector of componentIndexer.getAllSelectors()) {
-              if (selector.includes(selectorInProgress)) {
-                const component = componentIndexer.getComponent(selector);
-                const item = new CompletionItem(selector);
-                item.commitCharacters = ['>'];
-                item.documentation = `angular-auto-import: add and import ${component?.componentName} from ${component?.path}`;
-                item.command = { title: 'import component', command: 'angular-auto-import.importComponent', arguments: [selector] };
-                suggestions.push(item);
-              }
+    // Register quick fix provider
+    activationContext.subscriptions.push(
+      vscode.languages.registerCodeActionsProvider(
+        { scheme: 'file', language: 'html' }, 
+        new QuickfixImportProvider(), 
+        {
+          providedCodeActionKinds: QuickfixImportProvider.providedCodeActionKinds,
+        }
+      )
+    );
+
+    // Register command to do element importing
+    const importCommand = vscode.commands.registerCommand('angular-auto-import.importElement', (selector: string) =>
+      importElement(angularIndexer.getElement(selector))
+    );
+    activationContext.subscriptions.push(importCommand);
+
+    // Register manual import command
+    const manualImportCommand = vscode.commands.registerCommand('angular-auto-import.manual.importElement', () => {
+      vscode.window
+        .showInputBox({
+          prompt: 'Enter Angular element selector or pipe name',
+          placeHolder: 'e.g., app-component, myPipe, myDirective',
+          value: '',
+        })
+        .then((userInput) => {
+          if (userInput) {
+            const success = importElement(angularIndexer.getElement(userInput));
+            if (!success) {
+              vscode.window.showErrorMessage(`Angular element "${userInput}" not found.`);
             }
           }
+        });
+    });
+    activationContext.subscriptions.push(manualImportCommand);
 
-          return suggestions;
-        },
-      }
-    )
-  );
+    // Register autocompletion for HTML files
+    activationContext.subscriptions.push(
+      vscode.languages.registerCompletionItemProvider(
+        { scheme: 'file', language: 'html' },
+        {
+          provideCompletionItems(
+            document: vscode.TextDocument,
+            position: vscode.Position,
+            token: vscode.CancellationToken,
+            context: vscode.CompletionContext
+          ) {
+            const linePrefix = document.lineAt(position).text.slice(0, position.character);
+            const suggestions: CompletionItem[] = [];
+            
+            // Match HTML tags for components and directives
+            const tagRegex = /<([^\s>]*)$/;
+            const tagMatch = tagRegex.exec(linePrefix);
+            
+            // Match pipe usage
+            const pipeRegex = /\|\s*(\w*)$/;
+            const pipeMatch = pipeRegex.exec(linePrefix);
+            
+            if (tagMatch && tagMatch[1]) {
+              const selectorInProgress = tagMatch[1];
+              for (const selector of angularIndexer.getAllSelectors()) {
+                const element = angularIndexer.getElement(selector);
+                if (element && (element.type === 'component' || element.type === 'directive') && 
+                    selector.includes(selectorInProgress)) {
+                  const item = new CompletionItem(selector, vscode.CompletionItemKind.Class);
+                  item.commitCharacters = ['>'];
+                  item.documentation = `angular-auto-import: add and import ${element.name} (${element.type}) from ${element.path}`;
+                  item.command = { 
+                    title: `import ${element.type}`, 
+                    command: 'angular-auto-import.importElement', 
+                    arguments: [selector] 
+                  };
+                  suggestions.push(item);
+                }
+              }
+            } else if (pipeMatch && pipeMatch[1]) {
+              const pipeNameInProgress = pipeMatch[1];
+              for (const selector of angularIndexer.getAllSelectors()) {
+                const element = angularIndexer.getElement(selector);
+                if (element && element.type === 'pipe' && selector.includes(pipeNameInProgress)) {
+                  const item = new CompletionItem(selector, vscode.CompletionItemKind.Function);
+                  item.documentation = `angular-auto-import: add and import ${element.name} (pipe) from ${element.path}`;
+                  item.command = { 
+                    title: 'import pipe', 
+                    command: 'angular-auto-import.importElement', 
+                    arguments: [selector] 
+                  };
+                  suggestions.push(item);
+                }
+              }
+            }
+
+            return suggestions;
+          },
+        }
+      )
+    );
+
+    console.log('Angular Auto-Import extension activated successfully');
+  } catch (error) {
+    console.error('Error activating Angular Auto-Import extension:', error);
+    vscode.window.showErrorMessage('Failed to activate Angular Auto-Import extension. Check console for details.');
+  }
 }
 
 export function deactivate() {
-  if (componentIndexer) {
-    componentIndexer.dispose();
+  if (angularIndexer) {
+    angularIndexer.dispose();
   }
   if (interval) {
     clearInterval(interval);
@@ -651,32 +801,196 @@ export function deactivate() {
 
 export class QuickfixImportProvider implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
-  public static readonly fixesDiagnosticCode: number[] = [-998001];
+
+  // Common Angular diagnostic codes for unknown elements/pipes
+  public static readonly fixesDiagnosticCode: number[] = [-998001, -998002, -998003];
 
   provideCodeActions(
-    document: vscode.TextDocument,
-    range: vscode.Range,
-    context: vscode.CodeActionContext,
-    token: vscode.CancellationToken
+      document: vscode.TextDocument,
+      range: vscode.Range,
+      context: vscode.CodeActionContext,
+      token: vscode.CancellationToken
   ): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+    const actions: vscode.CodeAction[] = [];
+
     for (const diagnostic of context.diagnostics) {
-      if (diagnostic.code && typeof diagnostic.code === 'number' && QuickfixImportProvider.fixesDiagnosticCode.includes(diagnostic.code)) {
-        let selector = document.getText(diagnostic.range);
-        if (selector.startsWith('<') && selector.endsWith('>')) {
-          selector = selector.slice(1, selector.length - 1);
-          const component = componentIndexer.getComponent(selector);
-          if (component) {
-            const fix = new vscode.CodeAction(
-              `angular-auto-import: Import component ${component.componentName} from ${component.path}`,
-              vscode.CodeActionKind.QuickFix
-            );
-            fix.command = { title: 'import component', command: 'angular-auto-import.importComponent', arguments: [selector] };
-            fix.diagnostics = [diagnostic];
-            return [fix];
+      if (this.isFixableDiagnostic(diagnostic)) {
+        const quickFixes = this.createQuickFixesForDiagnostic(document, diagnostic);
+        actions.push(...quickFixes);
+      }
+    }
+
+    // Also provide quick fixes for unknown elements even without specific diagnostics
+    const additionalFixes = this.createQuickFixesForRange(document, range);
+    actions.push(...additionalFixes);
+
+    return actions;
+  }
+
+  private isFixableDiagnostic(diagnostic: vscode.Diagnostic): boolean {
+    // Check if diagnostic code matches our fixable codes
+    if (diagnostic.code && typeof diagnostic.code === 'number') {
+      return QuickfixImportProvider.fixesDiagnosticCode.includes(diagnostic.code);
+    }
+
+    // Check if diagnostic message indicates unknown element/pipe
+    const message = diagnostic.message.toLowerCase();
+    return message.includes('is not a known element') ||
+        message.includes('is not a known pipe') ||
+        message.includes('unknown element') ||
+        message.includes('unknown pipe');
+  }
+
+  private createQuickFixesForDiagnostic(
+      document: vscode.TextDocument,
+      diagnostic: vscode.Diagnostic
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    let selector = document.getText(diagnostic.range).trim();
+
+    // Handle different selector formats
+    selector = this.extractSelector(selector);
+
+    if (selector && angularIndexer) {
+      const element = angularIndexer.getElement(selector);
+      if (element) {
+        const action = this.createCodeAction(element, selector, diagnostic);
+        if (action) {
+          actions.push(action);
+        }
+      } else {
+        // Try to find partial matches
+        const partialMatches = this.findPartialMatches(selector);
+        partialMatches.forEach(match => {
+          const partialAction = this.createCodeAction(match, match.selector, diagnostic);
+          if (partialAction) {
+            actions.push(partialAction);
           }
+        });
+      }
+    }
+
+    return actions;
+  }
+
+  private createQuickFixesForRange(
+      document: vscode.TextDocument,
+      range: vscode.Range
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    const text = document.getText(range).trim();
+
+    if (!text || !angularIndexer) {
+      return actions;
+    }
+
+    // Extract potential selectors from the range
+    const selectors = this.extractSelectorsFromText(text);
+
+    selectors.forEach(selector => {
+      const element = angularIndexer.getElement(selector);
+      if (element) {
+        const action = this.createCodeAction(element, selector);
+        if (action) {
+          actions.push(action);
+        }
+      }
+    });
+
+    return actions;
+  }
+
+  private extractSelector(text: string): string {
+    // Remove HTML tag brackets
+    if (text.startsWith('<') && text.endsWith('>')) {
+      text = text.slice(1, -1);
+    }
+
+    // Remove attributes and get just the tag name
+    const tagMatch = text.match(/^([^\s]+)/);
+    if (tagMatch) {
+      return tagMatch[1];
+    }
+
+    // Handle pipe syntax
+    const pipeMatch = text.match(/\|\s*(\w+)/);
+    if (pipeMatch) {
+      return pipeMatch[1];
+    }
+
+    return text;
+  }
+
+  private extractSelectorsFromText(text: string): string[] {
+    const selectors: string[] = [];
+
+    // Extract HTML tag selectors
+    const tagRegex = /<([a-zA-Z][a-zA-Z0-9-]*)/g;
+    let tagMatch;
+    while ((tagMatch = tagRegex.exec(text)) !== null) {
+      selectors.push(tagMatch[1]);
+    }
+
+    // Extract pipe selectors
+    const pipeRegex = /\|\s*([a-zA-Z][a-zA-Z0-9]*)/g;
+    let pipeMatch;
+    while ((pipeMatch = pipeRegex.exec(text)) !== null) {
+      selectors.push(pipeMatch[1]);
+    }
+
+    return [...new Set(selectors)]; // Remove duplicates
+  }
+
+  private findPartialMatches(selector: string): Array<{selector: string} & AngularElementData> {
+    if (!angularIndexer) {
+      return [];
+    }
+
+    const matches: Array<{selector: string} & AngularElementData> = [];
+    const lowerSelector = selector.toLowerCase();
+
+    for (const availableSelector of angularIndexer.getAllSelectors()) {
+      if (availableSelector.toLowerCase().includes(lowerSelector) ||
+          lowerSelector.includes(availableSelector.toLowerCase())) {
+        const element = angularIndexer.getElement(availableSelector);
+        if (element) {
+          matches.push({
+            selector: availableSelector,
+            ...element
+          });
         }
       }
     }
-    return [];
+
+    return matches.slice(0, 5); // Limit to 5 suggestions
+  }
+
+  private createCodeAction(
+      element: AngularElementData,
+      selector: string,
+      diagnostic?: vscode.Diagnostic
+  ): vscode.CodeAction | null {
+    const elementType = element.type;
+    const actionTitle = `Import ${element.name} (${elementType}) from ${element.path}`;
+
+    const action = new vscode.CodeAction(
+        actionTitle,
+        vscode.CodeActionKind.QuickFix
+    );
+
+    action.command = {
+      title: `Import ${elementType}`,
+      command: 'angular-auto-import.importElement',
+      arguments: [selector]
+    };
+
+    if (diagnostic) {
+      action.diagnostics = [diagnostic];
+    }
+
+    // Set action priority (higher number = higher priority)
+    action.isPreferred = element.type === 'component';
+
+    return action;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,14 +31,19 @@ class AngularElementData {
 
 // Enhanced caching and indexing
 class AngularIndexer {
-  private parser: any;
+  private parser: Parser; // Typed Parser
   private fileCache: Map<string, ComponentInfo> = new Map();
   private selectorToElement: Map<string, AngularElementData> = new Map();
   private fileWatcher: vscode.FileSystemWatcher | null = null;
+  private projectRootPath: string = ''; // Store project root path
 
   constructor() {
     this.parser = new Parser();
     this.parser.setLanguage(TypeScript);
+  }
+
+  public setProjectRoot(projectPath: string) {
+    this.projectRootPath = projectPath;
   }
 
   /**
@@ -49,6 +54,10 @@ class AngularIndexer {
     if (this.fileWatcher) {
       this.fileWatcher.dispose();
     }
+    // Ensure projectRootPath is set if not already
+    if (!this.projectRootPath) {
+      this.projectRootPath = projectPath;
+    }
 
     // Watch for Angular file changes (components, directives, pipes)
     const pattern = new vscode.RelativePattern(projectPath, '**/*.{component,directive,pipe}.ts');
@@ -56,12 +65,12 @@ class AngularIndexer {
 
     this.fileWatcher.onDidCreate((uri) => {
       console.log(`File created: ${uri.fsPath}`);
-      this.updateFileIndex(uri.fsPath, projectPath, context);
+      this.updateFileIndex(uri.fsPath, context); // projectPath removed, uses this.projectRootPath
     });
 
     this.fileWatcher.onDidChange((uri) => {
       console.log(`File changed: ${uri.fsPath}`);
-      this.updateFileIndex(uri.fsPath, projectPath, context);
+      this.updateFileIndex(uri.fsPath, context); // projectPath removed, uses this.projectRootPath
     });
 
     this.fileWatcher.onDidDelete((uri) => {
@@ -89,67 +98,98 @@ class AngularIndexer {
    * Parse Angular element using Tree-sitter
    */
   private parseAngularElementWithTreeSitter(filePath: string, content: string): ComponentInfo | null {
+    if (!this.projectRootPath) {
+      console.error("AngularIndexer.projectRootPath is not set. Cannot determine relative path.");
+      // Attempt to use a fallback or simply return null if critical
+      // For now, let's assume it should have been set by `activate`
+      // If this error occurs, it's a bug in the initialization sequence.
+      return this.parseAngularElementWithRegex(filePath, content); // Fallback or could throw
+    }
     try {
       const tree = this.parser.parse(content);
       const rootNode = tree.rootNode;
+      let foundElement: ComponentInfo | null = null;
 
-      let selector: string | undefined;
-      let elementName: string | undefined;
-      let elementType: 'component' | 'directive' | 'pipe' | undefined;
-      let pipeName: string | undefined;
+      const findClassInfo = (classNode: Parser.SyntaxNode): ComponentInfo | null => {
+        let elementName: string | undefined;
+        let isExported = false;
 
-      // Find decorator and class export
-      this.traverseNode(rootNode, (node) => {
-        if (node.type === 'decorator') {
-          const decoratorNode = node.children.find((child: any) => child.type === 'call_expression');
-          if (decoratorNode) {
-            const functionNode = decoratorNode.children.find((child: any) => child.type === 'identifier');
-            if (functionNode) {
-              const decoratorName = content.slice(functionNode.startIndex, functionNode.endIndex);
-              
+        // Check for export: export class MyClass ...
+        // For `export class X {}`, class_declaration is typically a child of export_statement.
+        if (classNode.parent && classNode.parent.type === 'export_statement') {
+          // Check if this class_declaration is the main declaration of the export_statement
+          // This handles `export class Foo {}` and `export default class Foo {}`
+          if (classNode.parent.childForFieldName('declaration') === classNode ||
+              classNode.parent.children.some(child => child === classNode)) { // General check
+            isExported = true;
+          }
+        }
+
+        const nameIdentifier = classNode.childForFieldName('name');
+        if (nameIdentifier && nameIdentifier.type === 'identifier') {
+          elementName = content.slice(nameIdentifier.startIndex, nameIdentifier.endIndex);
+        }
+
+        if (!isExported || !elementName) return null;
+
+        let selector: string | undefined;
+        let elementType: 'component' | 'directive' | 'pipe' | undefined;
+        let pipeNameValue: string | undefined;
+
+        const decorators = classNode.children.filter(child => child.type === 'decorator');
+
+        for (const decoratorNode of decorators) {
+          const callExprNode = decoratorNode.firstChild; // Decorator is @Expr or @Expr()
+          if (callExprNode && callExprNode.type === 'call_expression') {
+            const funcIdentNode = callExprNode.childForFieldName('function');
+            if (funcIdentNode && funcIdentNode.type === 'identifier') {
+              const decoratorName = content.slice(funcIdentNode.startIndex, funcIdentNode.endIndex);
+
               if (decoratorName === 'Component') {
                 elementType = 'component';
-                selector = this.extractSelectorFromDecorator(decoratorNode, content);
+                selector = this.extractSelectorFromDecorator(callExprNode, content);
+                break;
               } else if (decoratorName === 'Directive') {
                 elementType = 'directive';
-                selector = this.extractSelectorFromDecorator(decoratorNode, content);
+                selector = this.extractSelectorFromDecorator(callExprNode, content);
+                break;
               } else if (decoratorName === 'Pipe') {
                 elementType = 'pipe';
-                pipeName = this.extractPipeNameFromDecorator(decoratorNode, content);
+                pipeNameValue = this.extractPipeNameFromDecorator(callExprNode, content);
+                break;
               }
             }
           }
         }
-      });
 
-      // Find exported class name
+        if (elementName && elementType) {
+          const finalSelector = elementType === 'pipe' ? pipeNameValue : selector;
+          if (finalSelector) {
+            return {
+              path: path.relative(this.projectRootPath, filePath),
+              name: elementName,
+              selector: finalSelector,
+              lastModified: fs.statSync(filePath).mtime.getTime(),
+              hash: this.generateHash(content),
+              type: elementType
+            };
+          }
+        }
+        return null;
+      };
+
       this.traverseNode(rootNode, (node) => {
-        if (node.type === 'export_statement') {
-          const classNode = node.children.find((child: any) => child.type === 'class_declaration');
-          if (classNode) {
-            const nameNode = classNode.children.find((child: any) => child.type === 'identifier');
-            if (nameNode) {
-              elementName = content.slice(nameNode.startIndex, nameNode.endIndex);
-            }
+        if (foundElement) return; // Optimization: assume one main Angular element per file
+
+        if (node.type === 'class_declaration') {
+          const info = findClassInfo(node);
+          if (info) {
+            foundElement = info;
           }
         }
       });
 
-      if (elementName && elementType) {
-        const finalSelector = elementType === 'pipe' ? pipeName : selector;
-        if (finalSelector) {
-          return {
-            path: path.relative(this.getProjectPath(), filePath),
-            name: elementName,
-            selector: finalSelector,
-            lastModified: fs.statSync(filePath).mtime.getTime(),
-            hash: this.generateHash(content),
-            type: elementType
-          };
-        }
-      }
-
-      return null;
+      return foundElement;
     } catch (error) {
       console.error(`Tree-sitter parsing error for ${filePath}:`, error);
       return this.parseAngularElementWithRegex(filePath, content); // Fallback to regex
@@ -159,27 +199,26 @@ class AngularIndexer {
   /**
    * Extract selector from @Component or @Directive decorator
    */
-  private extractSelectorFromDecorator(decoratorNode: any, content: string): string | undefined {
-    const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
+  private extractSelectorFromDecorator(decoratorCallExpressionNode: Parser.SyntaxNode, content: string): string | undefined {
+    const argsNode = decoratorCallExpressionNode.childForFieldName('arguments');
     if (argsNode) {
-      const objectNode = argsNode.children.find((child: any) => child.type === 'object');
+      // Arguments node is typically a parenthesized list, its first significant child is the object literal
+      const objectNode = argsNode.children.find((child: Parser.SyntaxNode) => child.type === 'object');
       if (objectNode) {
-        let selector: string | undefined;
-        this.traverseNode(objectNode, (propNode) => {
-          if (propNode.type === 'property_assignment') {
-            const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
-            const valueNode = propNode.children.find((child: any) => child.type === 'string');
-            
-            if (nameNode && valueNode) {
+        for (const propNode of objectNode.children) {
+          if (propNode.type === 'property_assignment') { // In some grammars 'pair'
+            const nameNode = propNode.childForFieldName('key') || propNode.children.find(c => c.type === 'property_identifier');
+            const valueNode = propNode.childForFieldName('value') || propNode.children.find(c => c.type === 'string');
+
+            if (nameNode && valueNode && nameNode.type === 'property_identifier' && valueNode.type === 'string') {
               const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
               if (propName === 'selector') {
                 const selectorValue = content.slice(valueNode.startIndex, valueNode.endIndex);
-                selector = selectorValue.slice(1, -1); // Remove quotes
+                return selectorValue.slice(1, -1); // Remove quotes
               }
             }
           }
-        });
-        return selector;
+        }
       }
     }
     return undefined;
@@ -188,27 +227,25 @@ class AngularIndexer {
   /**
    * Extract name from @Pipe decorator
    */
-  private extractPipeNameFromDecorator(decoratorNode: any, content: string): string | undefined {
-    const argsNode = decoratorNode.children.find((child: any) => child.type === 'arguments');
+  private extractPipeNameFromDecorator(decoratorCallExpressionNode: Parser.SyntaxNode, content: string): string | undefined {
+    const argsNode = decoratorCallExpressionNode.childForFieldName('arguments');
     if (argsNode) {
-      const objectNode = argsNode.children.find((child: any) => child.type === 'object');
+      const objectNode = argsNode.children.find((child: Parser.SyntaxNode) => child.type === 'object');
       if (objectNode) {
-        let pipeName: string | undefined;
-        this.traverseNode(objectNode, (propNode) => {
-          if (propNode.type === 'property_assignment') {
-            const nameNode = propNode.children.find((child: any) => child.type === 'property_identifier');
-            const valueNode = propNode.children.find((child: any) => child.type === 'string');
-            
-            if (nameNode && valueNode) {
+        for (const propNode of objectNode.children) {
+          if (propNode.type === 'property_assignment') { // In some grammars 'pair'
+            const nameNode = propNode.childForFieldName('key') || propNode.children.find(c => c.type === 'property_identifier');
+            const valueNode = propNode.childForFieldName('value') || propNode.children.find(c => c.type === 'string');
+
+            if (nameNode && valueNode && nameNode.type === 'property_identifier' && valueNode.type === 'string') {
               const propName = content.slice(nameNode.startIndex, nameNode.endIndex);
               if (propName === 'name') {
                 const nameValue = content.slice(valueNode.startIndex, valueNode.endIndex);
-                pipeName = nameValue.slice(1, -1); // Remove quotes
+                return nameValue.slice(1, -1); // Remove quotes
               }
             }
           }
-        });
-        return pipeName;
+        }
       }
     }
     return undefined;
@@ -218,13 +255,17 @@ class AngularIndexer {
    * Fallback regex parsing
    */
   private parseAngularElementWithRegex(filePath: string, content: string): ComponentInfo | null {
+    if (!this.projectRootPath) {
+      console.error("AngularIndexer.projectRootPath is not set for regex parsing.");
+      return null; // Cannot determine relative path
+    }
     const selectorRegex = /selector:\s*['"]([^'"]*)['"]/;
     const pipeNameRegex = /name:\s*['"]([^'"]*)['"]/;
     const classNameRegex = /export\s+class\s+(\w+)/;
 
     const fileName = path.basename(filePath);
     let elementType: 'component' | 'directive' | 'pipe';
-    
+
     if (fileName.includes('.component.')) {
       elementType = 'component';
     } else if (fileName.includes('.directive.')) {
@@ -251,7 +292,7 @@ class AngularIndexer {
 
     if (selector) {
       return {
-        path: path.relative(this.getProjectPath(), filePath),
+        path: path.relative(this.projectRootPath, filePath),
         name: classNameMatch[1],
         selector,
         lastModified: fs.statSync(filePath).mtime.getTime(),
@@ -266,44 +307,57 @@ class AngularIndexer {
   /**
    * Traverse Tree-sitter node recursively
    */
-  private traverseNode(node: any, callback: (node: any) => void) {
+  private traverseNode(node: Parser.SyntaxNode, callback: (node: Parser.SyntaxNode) => void) {
     callback(node);
     for (let i = 0; i < node.childCount; i++) {
-      this.traverseNode(node.child(i), callback);
+      const child = node.child(i);
+      if (child) { // Ensure child is not null
+        this.traverseNode(child, callback);
+      }
     }
   }
 
   /**
    * Update index for a single file
    */
-  private async updateFileIndex(filePath: string, projectPath: string, context: vscode.ExtensionContext): Promise<void> {
+  private async updateFileIndex(filePath: string, context: vscode.ExtensionContext): Promise<void> {
     try {
       if (!fs.existsSync(filePath)) {
         return;
       }
+      if (!this.projectRootPath) {
+        console.warn(`Project root path not set in AngularIndexer, cannot update index for ${filePath}`);
+        // Attempt to set it if global projectPath is available, otherwise this file can't be processed correctly.
+        // This situation should ideally be avoided by proper initialization.
+        const currentGlobalProjectPath = getGlobalProjectPath(); // Helper to get the global var if available
+        if (currentGlobalProjectPath) {
+          this.setProjectRoot(currentGlobalProjectPath);
+        } else {
+          return;
+        }
+      }
+
 
       const stats = fs.statSync(filePath);
       const lastModified = stats.mtime.getTime();
 
-      // Check if file needs reprocessing
       const cached = this.fileCache.get(filePath);
       if (cached && cached.lastModified >= lastModified) {
-        return; // File hasn't changed
+        return;
       }
 
       const content = fs.readFileSync(filePath, 'utf-8');
       const hash = this.generateHash(content);
 
-      // Check content hash to avoid reprocessing identical content
       if (cached && cached.hash === hash) {
+        // Update lastModified even if hash is same, to prevent re-reading file
+        this.fileCache.set(filePath, { ...cached, lastModified });
         return;
       }
 
-      // Parse Angular element using Tree-sitter
       const parsed = this.parseAngularElementWithTreeSitter(filePath, content);
-      
+
       if (parsed) {
-        // Remove old selector mapping if exists
         if (cached) {
           this.selectorToElement.delete(cached.selector);
         }
@@ -313,14 +367,11 @@ class AngularIndexer {
 
         console.log(`Updated index for: ${parsed.path} -> ${parsed.selector} (${parsed.type})`);
       } else {
-        // Remove from cache if parsing failed
         if (cached) {
           this.fileCache.delete(filePath);
           this.selectorToElement.delete(cached.selector);
         }
       }
-
-      // Persist to workspace state
       await this.saveIndexToWorkspace(context);
 
     } catch (error) {
@@ -346,37 +397,33 @@ class AngularIndexer {
    */
   async generateFullIndex(projectPath: string, context: vscode.ExtensionContext): Promise<Map<string, AngularElementData>> {
     console.log('INDEXING Angular elements with Tree-sitter...');
-    
+    this.setProjectRoot(projectPath); // Ensure project root is set
+
     const angularFiles = this.getAngularFiles(projectPath);
-    
-    // Process files in parallel batches to avoid overwhelming the system
+
     const batchSize = 10;
     for (let i = 0; i < angularFiles.length; i += batchSize) {
       const batch = angularFiles.slice(i, i + batchSize);
-      const batchTasks = batch.map(file => 
-        this.updateFileIndex(path.join(projectPath, file), projectPath, context)
+      // Pass context for each updateFileIndex call
+      const batchTasks = batch.map(file =>
+          this.updateFileIndex(path.join(projectPath, file), context)
       );
-      
-      // Wait for batch to complete before starting next batch
       await Promise.all(batchTasks);
     }
 
     console.log(`Indexed ${this.selectorToElement.size} Angular elements using Tree-sitter`);
+    await this.saveIndexToWorkspace(context); // Save once after full index
     return this.selectorToElement;
   }
 
-  /**
-   * Load index from workspace state
-   */
   loadFromWorkspace(context: vscode.ExtensionContext): boolean {
     try {
-      const storedCache = context.workspaceState.get('angularFileCache');
-      const storedIndex = context.workspaceState.get('angularSelectorToDataIndex');
+      const storedCache = context.workspaceState.get<Record<string, ComponentInfo>>('angularFileCache');
+      const storedIndex = context.workspaceState.get<Record<string, AngularElementData>>('angularSelectorToDataIndex');
 
       if (storedCache && storedIndex) {
-        // Convert plain objects back to Maps
-        this.fileCache = new Map(Object.entries(storedCache as Record<string, ComponentInfo>));
-        this.selectorToElement = new Map(Object.entries(storedIndex as Record<string, AngularElementData>).map(([key, value]) => [
+        this.fileCache = new Map(Object.entries(storedCache));
+        this.selectorToElement = new Map(Object.entries(storedIndex).map(([key, value]) => [
           key,
           new AngularElementData(value.path, value.name, value.type)
         ]));
@@ -389,9 +436,6 @@ class AngularIndexer {
     return false;
   }
 
-  /**
-   * Save index to workspace state
-   */
   private async saveIndexToWorkspace(context: vscode.ExtensionContext): Promise<void> {
     try {
       await context.workspaceState.update('angularFileCache', Object.fromEntries(this.fileCache));
@@ -401,40 +445,42 @@ class AngularIndexer {
     }
   }
 
-  /**
-   * Get Angular element by selector
-   */
   getElement(selector: string): AngularElementData | undefined {
     return this.selectorToElement.get(selector);
   }
 
-  /**
-   * Get all selectors
-   */
   getAllSelectors(): IterableIterator<string> {
     return this.selectorToElement.keys();
   }
 
-  /**
-   * Get Angular files (components, directives, pipes)
-   */
-  private getAngularFiles(filePath: string): string[] {
+  private getAngularFiles(basePath: string): string[] { // Renamed filePath to basePath for clarity
     const angularFiles: string[] = [];
 
     const isGitIgnored = (fileName: string, gitIgnorePath: string): boolean => {
       if (!fs.existsSync(gitIgnorePath)) return false;
-
       try {
         const gitIgnoreContent = fs.readFileSync(gitIgnorePath, 'utf-8');
         const gitIgnorePatterns = gitIgnoreContent.split('\n')
-          .map(line => line.trim())
-          .filter(line => line && !line.startsWith('#'));
+            .map(line => line.trim())
+            .filter(line => line && !line.startsWith('#'));
 
         return gitIgnorePatterns.some((pattern) => {
           try {
-            const regexp = new RegExp(pattern.replace(/\*/g, '.*').replace(/\?/g, '.'));
+            // Basic glob to regex: needs improvement for complex patterns
+            // Consider using a library like 'micromatch' for robust .gitignore parsing
+            const normalizedPattern = pattern.startsWith('/') ? pattern.substring(1) : `**/${pattern}`;
+            const regexp = new RegExp(
+                '^' +
+                normalizedPattern
+                    .replace(/\./g, '\\.') // Escape dots
+                    .replace(/\*\*/g, '(.+)?') // Match **
+                    .replace(/\*/g, '[^/]*') // Match *
+                    .replace(/\?/g, '[^/]') + // Match ?
+                '$'
+            );
             return regexp.test(fileName);
-          } catch {
+          } catch (e) {
+            // console.warn(`Invalid gitignore pattern: ${pattern}`, e);
             return false;
           }
         });
@@ -443,56 +489,51 @@ class AngularIndexer {
       }
     };
 
-    const traverseDirectory = (dirPath: string, gitIgnorePath?: string) => {
+    const traverseDirectory = (currentDirPath: string) => {
       try {
-        const files = fs.readdirSync(dirPath);
+        const files = fs.readdirSync(currentDirPath);
+        const gitIgnorePath = path.join(basePath, '.gitignore'); // .gitignore is usually at project root
 
         files.forEach((file) => {
-          const fullPath = path.join(dirPath, file);
-          const relativePath = path.relative(filePath, fullPath);
+          const fullPath = path.join(currentDirPath, file);
+          const relativePathToRoot = path.relative(basePath, fullPath); // Relative to project root for gitignore
 
-          if (gitIgnorePath && isGitIgnored(relativePath, gitIgnorePath)) {
+          if (isGitIgnored(relativePathToRoot, gitIgnorePath)) {
             return;
           }
 
           try {
             if (fs.statSync(fullPath).isDirectory()) {
-              // Skip node_modules and other common directories
-              if (!['node_modules', '.git', 'dist', 'build'].includes(file)) {
-                traverseDirectory(fullPath, gitIgnorePath);
+              if (!['node_modules', '.git', 'dist', 'build', 'out', '.vscode'].includes(file)) {
+                traverseDirectory(fullPath);
               }
             } else if (file.match(/\.(component|directive|pipe)\.ts$/)) {
-              angularFiles.push(relativePath);
+              angularFiles.push(relativePathToRoot); // Store path relative to basePath
             }
           } catch (error) {
-            console.warn(`Error processing file ${fullPath}:`, error);
+            // console.warn(`Error processing file/directory ${fullPath}:`, error);
           }
         });
       } catch (error) {
-        console.warn(`Error reading directory ${dirPath}:`, error);
+        // console.warn(`Error reading directory ${currentDirPath}:`, error);
       }
     };
 
-    if (fs.existsSync(filePath)) {
+    if (fs.existsSync(basePath)) {
       try {
-        const stats = fs.statSync(filePath);
+        const stats = fs.statSync(basePath);
         if (stats.isDirectory()) {
-          const gitIgnorePath = path.join(filePath, '.gitignore');
-          traverseDirectory(filePath, gitIgnorePath);
-        } else if (filePath.match(/\.(component|directive|pipe)\.ts$/)) {
-          angularFiles.push(path.basename(filePath));
+          traverseDirectory(basePath);
+        } else if (basePath.match(/\.(component|directive|pipe)\.ts$/)) {
+          angularFiles.push(path.basename(basePath)); // If basePath is a file itself
         }
       } catch (error) {
-        console.error(`Error processing path ${filePath}:`, error);
+        console.error(`Error processing path ${basePath}:`, error);
       }
     }
-    
+
     console.log(`Found ${angularFiles.length} Angular files.`);
     return angularFiles;
-  }
-
-  private getProjectPath(): string {
-    return projectPath ?? '';
   }
 
   dispose() {
@@ -504,45 +545,65 @@ class AngularIndexer {
 
 // State
 let angularIndexer: AngularIndexer;
-let interval: any;
+let interval: NodeJS.Timeout | undefined; // Typed interval
 
 // Config
 let reindexInterval: number = 60;
-let projectPath: string | undefined;
+let currentProjectPath: string | undefined; // Renamed from projectPath to avoid confusion with local vars
 
-function getConfiguration() { 
+// Helper to access the global project path, primarily for updateFileIndex fallback
+function getGlobalProjectPath(): string | undefined {
+  return currentProjectPath;
+}
+
+function getConfiguration() {
   const config = vscode.workspace.getConfiguration('angular-auto-import');
-  reindexInterval = config.get('angular-auto-import.index.refreshInterval') ?? 60;
+  reindexInterval = config.get('index.refreshInterval', 60); // Corrected config key
   return config;
 }
 
-function getRelativeFilePath(file1: string, file2: string): string {
-  return path.relative(path.dirname(file1), file2);
+function getRelativeFilePath(fromFile: string, toFileNoExt: string): string {
+  const relative = path.relative(path.dirname(fromFile), toFileNoExt);
+  // Ensure it's a relative path for import statements
+  return relative.startsWith('.') ? relative : `./${relative}`;
 }
 
-function importElementToFile(element: AngularElementData, filePath: string): boolean {
+function importElementToFile(element: AngularElementData, componentFilePath: string): boolean {
   try {
-    const relativePath = getRelativeFilePath(filePath, `${projectPath}/${switchFileType(element.path, '')}`);
-    let importStr = `import { ${element.name} } from '${relativePath.startsWith('.') ? relativePath : './' + relativePath}';\n`;
-    
-    const fileContents = fs.readFileSync(filePath, 'utf-8');
-    
-    // Check if import already exists
-    const importRegex = new RegExp(`import\\s*{[^}]*\\b${element.name}\\b[^}]*}\\s*from\\s*['"][^'"]*['"]`, 'g');
-    if (importRegex.test(fileContents)) {
-      console.log(`${element.name} is already imported`);
-      return true;
+    if (!currentProjectPath) {
+      vscode.window.showErrorMessage('Project path is not defined. Cannot import element.');
+      return false;
+    }
+    // element.path is relative to project root, e.g., "src/app/my.component.ts"
+    // switchFileType removes the extension: "src/app/my.component"
+    const targetModulePathNoExt = path.join(currentProjectPath, switchFileType(element.path, ''));
+    const relativeImportPath = getRelativeFilePath(componentFilePath, targetModulePathNoExt);
+
+    let importStr = `import { ${element.name} } from '${relativeImportPath}';\n`;
+
+    const fileContents = fs.readFileSync(componentFilePath, 'utf-8');
+
+    const importRegex = new RegExp(`import\\s*{[^}]*\\b${element.name}\\b[^}]*}\\s*from\\s*['"]${relativeImportPath}['"]`, 'g');
+    const simplerImportRegex = new RegExp(`import\\s*{[^}]*\\b${element.name}\\b[^}]*}\\s*from`); // More generic check
+
+    if (simplerImportRegex.test(fileContents)) {
+      console.log(`${element.name} seems to be already imported or a class with the same name is imported.`);
+      // Check if it needs to be added to @Component imports anyway
+      const newFileContentsWithAnnotation = addImportToAnnotation(element, fileContents);
+      if (newFileContentsWithAnnotation !== fileContents) {
+        fs.writeFileSync(componentFilePath, newFileContentsWithAnnotation);
+        setTimeout(() => vscode.commands.executeCommand('editor.action.formatDocument') , 100);
+        return true; // Modified annotations
+      }
+      return true; // Already imported
     }
 
     let newFileContents = importStr + fileContents;
     newFileContents = addImportToAnnotation(element, newFileContents);
 
-    fs.writeFileSync(filePath, newFileContents);
-    
-    // Format document after a short delay
-    setTimeout(() => {
-      vscode.commands.executeCommand('editor.action.formatDocument') // .catch(console.error);
-    }, 100);
+    fs.writeFileSync(componentFilePath, newFileContents);
+
+    setTimeout(() => vscode.commands.executeCommand('editor.action.formatDocument') , 100);
 
     return true;
   } catch (e) {
@@ -552,57 +613,118 @@ function importElementToFile(element: AngularElementData, filePath: string): boo
 }
 
 function addImportToAnnotation(element: AngularElementData, fileContents: string): string {
-  const importRegex = /(@Component\({[\s\S]*?imports:\s*\[)([^\]]*?)(\][\s\S]*?}\))/;
-  
+  // Only add to imports array if it's a Component or Directive (or Module, if supported later)
+  if (element.type === 'pipe') {
+    return fileContents; // Pipes are typically not added to `imports` array of @Component
+  }
+
+  const importRegex = /(@Component\(\s*{[\s\S]*?imports:\s*\[)([^\]]*?)(\][\s\S]*?}\))/;
+  const componentDecoratorRegex = /@Component\(\s*{/; // To find where to insert `imports`
+
   if (importRegex.test(fileContents)) {
     return fileContents.replace(importRegex, (match, before, imports, after) => {
       const trimmedImports = imports.trim();
+      // Avoid adding if already present
+      if (new RegExp(`\\b${element.name}\\b`).test(trimmedImports)) {
+        return match;
+      }
       if (trimmedImports === '') {
         return `${before}${element.name}${after}`;
+      } else if (trimmedImports.endsWith(',')) {
+        return `${before}${trimmedImports} ${element.name}${after}`;
       } else {
         return `${before}${trimmedImports}, ${element.name}${after}`;
       }
     });
+  } else if (componentDecoratorRegex.test(fileContents)) {
+    // Add imports array to @Component decorator if `imports` doesn't exist
+    return fileContents.replace(componentDecoratorRegex, (match) => {
+      // Find the first property or the closing brace of the metadata object
+      const componentMetadata = fileContents.substring(match.length -1 + fileContents.indexOf(match)); // Get from @Component({
+      let insertPosition = componentMetadata.indexOf('}') + fileContents.indexOf(match) + match.length -1; // Default to before closing }
+
+      // Try to insert after `templateUrl: '...',` or similar common properties
+      const commonPropsOrder = ['selector', 'templateUrl', 'styleUrls', 'styles', 'template'];
+      let lastPropEnd = -1;
+
+      const metadataObjectMatch = /@Component\(\s*({[\s\S]*?})\s*\)/.exec(fileContents);
+      if (metadataObjectMatch && metadataObjectMatch[1]) {
+        const metadataContent = metadataObjectMatch[1];
+        let tempOffset = 0;
+        for (const prop of commonPropsOrder) {
+          const propRegex = new RegExp(`${prop}:\\s*[^,}\\]]+[,\\s]*`);
+          const matchProp = propRegex.exec(metadataContent.substring(tempOffset));
+          if (matchProp) {
+            lastPropEnd = tempOffset + matchProp.index + matchProp[0].length;
+            tempOffset = lastPropEnd;
+          }
+        }
+        if (lastPropEnd !== -1) {
+          insertPosition = fileContents.indexOf(metadataObjectMatch[1]) + lastPropEnd;
+          const prefix = metadataContent.substring(0, lastPropEnd).trim().endsWith(',') ? ' ' : ', ';
+          return fileContents.substring(0, insertPosition) +
+              `${prefix}imports: [${element.name}]` +
+              fileContents.substring(insertPosition);
+        } else { // No common props found, insert at the beginning of the object
+          insertPosition = fileContents.indexOf(metadataObjectMatch[1]) + 1; // After {
+          return fileContents.substring(0, insertPosition) +
+              `imports: [${element.name}], ` +
+              fileContents.substring(insertPosition);
+        }
+      }
+      // Fallback if complex regex fails (should not happen if @Component exists)
+      return `${match}imports: [${element.name}],\n`;
+    });
+  }
+  return fileContents; // Should not happen if @Component exists
+}
+
+function switchFileType(filePath: string, newExtensionWithDot: string): string {
+  const dir = path.dirname(filePath);
+  const ext = path.extname(filePath);
+  const base = path.basename(filePath, ext); // e.g., 'my.component' from 'my.component.ts'
+
+  if (newExtensionWithDot === '') { // Request to remove extension
+    return path.join(dir, base);
   } else {
-    // Add imports array to @Component decorator
-    const componentRegex = /(@Component\({)(\s*)/;
-    return fileContents.replace(componentRegex, `$1$2imports: [${element.name}],$2`);
+    // Ensure newExtension starts with a dot if it's meant to be an extension
+    const finalExtension = newExtensionWithDot.startsWith('.') ? newExtensionWithDot : `.${newExtensionWithDot}`;
+    return path.join(dir, `${base}${finalExtension}`);
   }
 }
 
-function switchFileType(filePath: string, newExtension: string): string {
-  const fileBaseName = path.basename(filePath, path.extname(filePath));
-  const fileDirectory = path.dirname(filePath);
-
-  if (!newExtension) {
-    return path.join(fileDirectory, fileBaseName);
-  } else {
-    return path.join(fileDirectory, `${fileBaseName}.${newExtension}`);
-  }
-}
 
 function importElement(element?: AngularElementData): boolean {
   if (!element) {
-    console.error('Angular element not found. Please check that the provided selector is correct, reindex, and try again.');
-    vscode.window.showInformationMessage('Angular element not found. Please reindex and try again.');
+    vscode.window.showInformationMessage('Angular element not found. Please check selector, reindex, and try again.');
     return false;
   }
-  
-  const currentFile = vscode.window.activeTextEditor?.document.fileName;
-  if (!currentFile) {
+
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
     vscode.window.showErrorMessage('No active file found.');
     return false;
   }
-  
-  const activeComponentFile = switchFileType(currentFile, 'ts');
-  const success = importElementToFile(element, activeComponentFile);
-  
-  if (!success) {
-    vscode.window.showInformationMessage(`Something went wrong while importing your ${element.type}. Please try again.`);
-  } else {
-    vscode.window.showInformationMessage(`${element.type} ${element.name} imported successfully.`);
+  const currentFile = activeEditor.document.fileName;
+
+  // Assuming we are in an HTML file, find the corresponding .ts file
+  // This heuristic might need adjustment based on project structure
+  // e.g. my.component.html -> my.component.ts
+  const activeComponentFile = switchFileType(currentFile, '.ts');
+
+  if (!fs.existsSync(activeComponentFile)) {
+    vscode.window.showErrorMessage(`Component file not found for ${path.basename(currentFile)}. Expected ${path.basename(activeComponentFile)}.`);
+    return false;
   }
-  
+
+  const success = importElementToFile(element, activeComponentFile);
+
+  if (!success) {
+    vscode.window.showInformationMessage(`Something went wrong while importing ${element.type} ${element.name}. Please try again or check logs.`);
+  } else {
+    vscode.window.showInformationMessage(`${element.type} ${element.name} imported successfully into ${path.basename(activeComponentFile)}.`);
+  }
+
   return success;
 }
 
@@ -610,177 +732,181 @@ async function setAngularDataIndex(context: vscode.ExtensionContext) {
   if (!angularIndexer) {
     angularIndexer = new AngularIndexer();
   }
+  // Determine project path first and set it for the indexer
+  const projectRoot = determineProjectPath(); // Renamed from getProjectPath to avoid conflict
+  angularIndexer.setProjectRoot(projectRoot);
 
-  // Try to load from cache first
+
   if (angularIndexer.loadFromWorkspace(context)) {
+    // If loaded from cache, still ensure watcher is initialized with the correct project path
+    angularIndexer.initializeWatcher(context, projectRoot);
     return;
   }
-
-  // If cache is empty, generate full index
   await generateIndex(context);
 }
 
 async function generateIndex(context: vscode.ExtensionContext) {
-  const folderPath = getProjectPath();
+  const folderPath = determineProjectPath(); // Renamed
   if (!angularIndexer) {
     angularIndexer = new AngularIndexer();
   }
-  
+  angularIndexer.setProjectRoot(folderPath); // Ensure it's set before indexing
+
   await angularIndexer.generateFullIndex(folderPath, context);
-  
-  // Initialize file watcher for incremental updates
   angularIndexer.initializeWatcher(context, folderPath);
 }
 
-function getProjectPath(): string {
-  const config = getConfiguration();
-  projectPath = config.get('angular-auto-import.projectPath');
-  
-  if (!projectPath) {
-    const workspace = vscode.workspace;
-    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-      const firstFolder = workspace.workspaceFolders[0];
-      projectPath = firstFolder.uri.fsPath;
+function determineProjectPath(): string { // Renamed from getProjectPath
+  const config = getConfiguration(); // Ensure config is loaded
+  let pathFromConfig = config.get<string>('projectPath'); // Corrected config key
+
+  if (pathFromConfig && pathFromConfig.trim() !== "") {
+    currentProjectPath = pathFromConfig;
+  } else {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders && workspaceFolders.length > 0) {
+      currentProjectPath = workspaceFolders[0].uri.fsPath;
     } else {
-      console.error('No active folder found.');
-      throw new Error('No workspace folder found');
+      vscode.window.showErrorMessage('Angular Auto-Import: No workspace folder found and no project path configured. Please set "angular-auto-import.projectPath" or open a folder.');
+      throw new Error('No workspace folder found and no project path configured.');
     }
   }
-  
-  return projectPath;
+  console.log(`Angular Auto-Import: Using project path: ${currentProjectPath}`);
+  return currentProjectPath;
 }
 
 export async function activate(activationContext: vscode.ExtensionContext) {
   try {
-    // Get config settings
-    getConfiguration();
+    getConfiguration(); // Load configuration settings, including reindexInterval
+    currentProjectPath = determineProjectPath(); // Determine and set global currentProjectPath
 
-    // Set the index with optimized indexer
-    await setAngularDataIndex(activationContext);
+    angularIndexer = new AngularIndexer();
+    // Set project path for the indexer instance *before* any operations that might need it
+    angularIndexer.setProjectRoot(currentProjectPath);
 
-    // Register interval for periodic reindexing (optional, since we have file watchers)
+    await setAngularDataIndex(activationContext); // This will also init watcher
+
     if (interval) {
       clearInterval(interval);
     }
-    
-    if (reindexInterval !== 0) {
+
+    if (reindexInterval > 0) { // Check if interval is positive
       interval = setInterval(async () => {
         try {
+          console.log('Periodic reindexing triggered...');
           await generateIndex(activationContext);
         } catch (error) {
           console.error('Error during periodic reindexing:', error);
         }
-      }, Math.floor(reindexInterval) * 1000);
+      }, reindexInterval * 1000 * 60); // Interval is in minutes
+    } else {
+      console.log('Periodic reindexing is disabled (interval is 0 or less).');
     }
 
-    // Register reindex command
     const reindexCommand = vscode.commands.registerCommand('angular-auto-import.reindex', async () => {
       try {
+        vscode.window.showInformationMessage('angular-auto-import: Reindexing started...');
         await generateIndex(activationContext);
         vscode.window.showInformationMessage('angular-auto-import: Reindex successful.');
       } catch (error) {
         console.error('Reindex error:', error);
-        vscode.window.showInformationMessage('angular-auto-import: Something went wrong when reindexing. Some elements may be missing.');
+        vscode.window.showErrorMessage('angular-auto-import: Reindexing failed. Check console for details.');
       }
     });
     activationContext.subscriptions.push(reindexCommand);
 
-    // Register quick fix provider
     activationContext.subscriptions.push(
-      vscode.languages.registerCodeActionsProvider(
-        { scheme: 'file', language: 'html' }, 
-        new QuickfixImportProvider(), 
-        {
-          providedCodeActionKinds: QuickfixImportProvider.providedCodeActionKinds,
-        }
-      )
+        vscode.languages.registerCodeActionsProvider(
+            { scheme: 'file', language: 'html' },
+            new QuickfixImportProvider(angularIndexer), // Pass indexer
+            { providedCodeActionKinds: QuickfixImportProvider.providedCodeActionKinds }
+        )
     );
 
-    // Register command to do element importing
-    const importCommand = vscode.commands.registerCommand('angular-auto-import.importElement', (selector: string) =>
-      importElement(angularIndexer.getElement(selector))
-    );
+    const importCommand = vscode.commands.registerCommand('angular-auto-import.importElement', (selector: string) => {
+      if (!angularIndexer) {
+        vscode.window.showErrorMessage('Indexer not available.');
+        return;
+      }
+      importElement(angularIndexer.getElement(selector));
+    });
     activationContext.subscriptions.push(importCommand);
 
-    // Register manual import command
-    const manualImportCommand = vscode.commands.registerCommand('angular-auto-import.manual.importElement', () => {
-      vscode.window
-        .showInputBox({
-          prompt: 'Enter Angular element selector or pipe name',
-          placeHolder: 'e.g., app-component, myPipe, myDirective',
-          value: '',
-        })
-        .then((userInput) => {
-          if (userInput) {
-            const success = importElement(angularIndexer.getElement(userInput));
-            if (!success) {
-              vscode.window.showErrorMessage(`Angular element "${userInput}" not found.`);
-            }
-          }
-        });
+    const manualImportCommand = vscode.commands.registerCommand('angular-auto-import.manual.importElement', async () => {
+      if (!angularIndexer) {
+        vscode.window.showErrorMessage('Indexer not available.');
+        return;
+      }
+      const userInput = await vscode.window.showInputBox({
+        prompt: 'Enter Angular element selector or pipe name',
+        placeHolder: 'e.g., app-component, myPipe, myDirective',
+      });
+      if (userInput) {
+        const success = importElement(angularIndexer.getElement(userInput));
+        if (!success && !angularIndexer.getElement(userInput)) { // Check if element was actually not found
+          vscode.window.showErrorMessage(`Angular element "${userInput}" not found in index.`);
+        }
+      }
     });
     activationContext.subscriptions.push(manualImportCommand);
 
-    // Register autocompletion for HTML files
     activationContext.subscriptions.push(
-      vscode.languages.registerCompletionItemProvider(
-        { scheme: 'file', language: 'html' },
-        {
-          provideCompletionItems(
-            document: vscode.TextDocument,
-            position: vscode.Position,
-            token: vscode.CancellationToken,
-            context: vscode.CompletionContext
-          ) {
-            const linePrefix = document.lineAt(position).text.slice(0, position.character);
-            const suggestions: CompletionItem[] = [];
-            
-            // Match HTML tags for components and directives
-            const tagRegex = /<([^\s>]*)$/;
-            const tagMatch = tagRegex.exec(linePrefix);
-            
-            // Match pipe usage
-            const pipeRegex = /\|\s*(\w*)$/;
-            const pipeMatch = pipeRegex.exec(linePrefix);
-            
-            if (tagMatch && tagMatch[1]) {
-              const selectorInProgress = tagMatch[1];
-              for (const selector of angularIndexer.getAllSelectors()) {
-                const element = angularIndexer.getElement(selector);
-                if (element && (element.type === 'component' || element.type === 'directive') && 
-                    selector.includes(selectorInProgress)) {
-                  const item = new CompletionItem(selector, vscode.CompletionItemKind.Class);
-                  item.commitCharacters = ['>'];
-                  item.documentation = `angular-auto-import: add and import ${element.name} (${element.type}) from ${element.path}`;
-                  item.command = { 
-                    title: `import ${element.type}`, 
-                    command: 'angular-auto-import.importElement', 
-                    arguments: [selector] 
-                  };
-                  suggestions.push(item);
-                }
-              }
-            } else if (pipeMatch && pipeMatch[1]) {
-              const pipeNameInProgress = pipeMatch[1];
-              for (const selector of angularIndexer.getAllSelectors()) {
-                const element = angularIndexer.getElement(selector);
-                if (element && element.type === 'pipe' && selector.includes(pipeNameInProgress)) {
-                  const item = new CompletionItem(selector, vscode.CompletionItemKind.Function);
-                  item.documentation = `angular-auto-import: add and import ${element.name} (pipe) from ${element.path}`;
-                  item.command = { 
-                    title: 'import pipe', 
-                    command: 'angular-auto-import.importElement', 
-                    arguments: [selector] 
-                  };
-                  suggestions.push(item);
-                }
-              }
-            }
+        vscode.languages.registerCompletionItemProvider(
+            { scheme: 'file', language: 'html' },
+            {
+              provideCompletionItems(document, position, token, context) {
+                if (!angularIndexer) return [];
 
-            return suggestions;
-          },
-        }
-      )
+                const linePrefix = document.lineAt(position).text.slice(0, position.character);
+                const suggestions: CompletionItem[] = [];
+
+                const tagRegex = /<([a-zA-Z0-9-]*)$/; // Allow numbers in tags
+                const tagMatch = tagRegex.exec(linePrefix);
+
+                const pipeRegex = /\|\s*([a-zA-Z0-9]*)$/; // Allow numbers in pipe names
+                const pipeMatch = pipeRegex.exec(linePrefix);
+
+                if (tagMatch) { // tagMatch[1] can be empty string if just '<'
+                  const selectorInProgress = tagMatch[1];
+                  for (const selector of angularIndexer.getAllSelectors()) {
+                    const element = angularIndexer.getElement(selector);
+                    if (element && (element.type === 'component' || element.type === 'directive') &&
+                        selector.startsWith(selectorInProgress)) { // Use startsWith for better suggestion flow
+                      const item = new CompletionItem(selector, vscode.CompletionItemKind.Class);
+                      item.insertText = selector; // Ensure full selector is inserted
+                      item.detail = `Angular Auto-Import: ${element.type}`;
+                      item.documentation = `Import ${element.name} (${element.type}) from ${element.path}`;
+                      item.command = {
+                        title: `Import ${element.name}`,
+                        command: 'angular-auto-import.importElement',
+                        arguments: [selector]
+                      };
+                      suggestions.push(item);
+                    }
+                  }
+                } else if (pipeMatch) { // pipeMatch[1] can be empty string
+                  const pipeNameInProgress = pipeMatch[1];
+                  for (const selector of angularIndexer.getAllSelectors()) {
+                    const element = angularIndexer.getElement(selector);
+                    if (element && element.type === 'pipe' && selector.startsWith(pipeNameInProgress)) {
+                      const item = new CompletionItem(selector, vscode.CompletionItemKind.Function);
+                      item.insertText = selector;
+                      item.detail = `Angular Auto-Import: pipe`;
+                      item.documentation = `Import ${element.name} (pipe) from ${element.path}`;
+                      item.command = {
+                        title: `Import ${element.name}`,
+                        command: 'angular-auto-import.importElement',
+                        arguments: [selector]
+                      };
+                      suggestions.push(item);
+                    }
+                  }
+                }
+                return suggestions;
+              },
+            },
+            '<', '|' // Trigger characters
+        )
     );
 
     console.log('Angular Auto-Import extension activated successfully');
@@ -796,21 +922,27 @@ export function deactivate() {
   }
   if (interval) {
     clearInterval(interval);
+    interval = undefined;
   }
+  console.log('Angular Auto-Import extension deactivated.');
 }
 
 export class QuickfixImportProvider implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+  public static readonly fixesDiagnosticCode: (string | number)[] = [
+    'NG8001', 'NG8002', 'NG8003', 'NG8004', 'NG6004',
+    -998001, -998002, -998003
+  ];
 
-  // Common Angular diagnostic codes for unknown elements/pipes
-  public static readonly fixesDiagnosticCode: number[] = [-998001, -998002, -998003];
+  constructor(private indexer: AngularIndexer) {}
 
   provideCodeActions(
       document: vscode.TextDocument,
-      range: vscode.Range,
+      range: vscode.Range | vscode.Selection,
       context: vscode.CodeActionContext,
       token: vscode.CancellationToken
   ): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+    if (!this.indexer) return [];
     const actions: vscode.CodeAction[] = [];
 
     for (const diagnostic of context.diagnostics) {
@@ -819,24 +951,19 @@ export class QuickfixImportProvider implements vscode.CodeActionProvider {
         actions.push(...quickFixes);
       }
     }
-
-    // Also provide quick fixes for unknown elements even without specific diagnostics
-    const additionalFixes = this.createQuickFixesForRange(document, range);
-    actions.push(...additionalFixes);
-
     return actions;
   }
 
   private isFixableDiagnostic(diagnostic: vscode.Diagnostic): boolean {
-    // Check if diagnostic code matches our fixable codes
-    if (diagnostic.code && typeof diagnostic.code === 'number') {
-      return QuickfixImportProvider.fixesDiagnosticCode.includes(diagnostic.code);
+    if (diagnostic.code) {
+      const codeStr = String(diagnostic.code);
+      if (QuickfixImportProvider.fixesDiagnosticCode.some(c => String(c) === codeStr)) {
+        return true;
+      }
     }
-
-    // Check if diagnostic message indicates unknown element/pipe
     const message = diagnostic.message.toLowerCase();
     return message.includes('is not a known element') ||
-        message.includes('is not a known pipe') ||
+        (message.includes('pipe') && message.includes('could not be found')) ||
         message.includes('unknown element') ||
         message.includes('unknown pipe');
   }
@@ -846,150 +973,103 @@ export class QuickfixImportProvider implements vscode.CodeActionProvider {
       diagnostic: vscode.Diagnostic
   ): vscode.CodeAction[] {
     const actions: vscode.CodeAction[] = [];
-    let selector = document.getText(diagnostic.range).trim();
+    let extractedTerm = document.getText(diagnostic.range).trim();
+    const message = diagnostic.message;
+    let termFromMessage: string | null = null;
 
-    // Handle different selector formats
-    selector = this.extractSelector(selector);
+    const knownElementMatch = /['"]([^'"]+)['"]\s+is\s+not\s+a\s+known\s+element/i.exec(message);
+    if (knownElementMatch && knownElementMatch[1]) {
+      termFromMessage = knownElementMatch[1];
+    } else {
+      const pipeMatch = /pipe\s+['"]([^'"]+)['"]\s+could\s+not\s+be\s+found/i.exec(message);
+      if (pipeMatch && pipeMatch[1]) {
+        termFromMessage = pipeMatch[1];
+      }
+    }
 
-    if (selector && angularIndexer) {
-      const element = angularIndexer.getElement(selector);
-      if (element) {
-        const action = this.createCodeAction(element, selector, diagnostic);
-        if (action) {
-          actions.push(action);
-        }
+    // selectorToSearch is the term we believe is the problematic selector/pipe name
+    const selectorToSearch = this.extractSelector(termFromMessage || extractedTerm);
+
+    if (selectorToSearch) {
+      const elementData = this.indexer.getElement(selectorToSearch); // elementData is AngularElementData | undefined
+      if (elementData) {
+        // Direct match found using selectorToSearch
+        // For createCodeAction:
+        // - element: elementData
+        // - elementActualSelector: selectorToSearch (this is the selector that led to elementData)
+        // - originalTermFromDiagnostic: selectorToSearch (this is what we searched for)
+        const action = this.createCodeAction(elementData, selectorToSearch, selectorToSearch, diagnostic);
+        if (action) actions.push(action);
       } else {
-        // Try to find partial matches
-        const partialMatches = this.findPartialMatches(selector);
-        partialMatches.forEach(match => {
-          const partialAction = this.createCodeAction(match, match.selector, diagnostic);
-          if (partialAction) {
-            actions.push(partialAction);
-          }
+        // No direct match, try partial matches
+        const partialMatches = this.findPartialMatches(selectorToSearch);
+        partialMatches.forEach(matchData => {
+          // matchData is (AngularElementData & {selector: string})
+          // For createCodeAction:
+          // - element: matchData (which is compatible with AngularElementData)
+          // - elementActualSelector: matchData.selector (the actual selector of this partially matched item)
+          // - originalTermFromDiagnostic: selectorToSearch (what we originally searched for)
+          const partialAction = this.createCodeAction(matchData, matchData.selector, selectorToSearch, diagnostic);
+          if (partialAction) actions.push(partialAction);
         });
       }
     }
-
-    return actions;
-  }
-
-  private createQuickFixesForRange(
-      document: vscode.TextDocument,
-      range: vscode.Range
-  ): vscode.CodeAction[] {
-    const actions: vscode.CodeAction[] = [];
-    const text = document.getText(range).trim();
-
-    if (!text || !angularIndexer) {
-      return actions;
-    }
-
-    // Extract potential selectors from the range
-    const selectors = this.extractSelectorsFromText(text);
-
-    selectors.forEach(selector => {
-      const element = angularIndexer.getElement(selector);
-      if (element) {
-        const action = this.createCodeAction(element, selector);
-        if (action) {
-          actions.push(action);
-        }
-      }
-    });
-
     return actions;
   }
 
   private extractSelector(text: string): string {
-    // Remove HTML tag brackets
     if (text.startsWith('<') && text.endsWith('>')) {
       text = text.slice(1, -1);
     }
+    const tagMatch = text.match(/^([a-zA-Z0-9-]+)/);
+    if (tagMatch) return tagMatch[1];
 
-    // Remove attributes and get just the tag name
-    const tagMatch = text.match(/^([^\s]+)/);
-    if (tagMatch) {
-      return tagMatch[1];
-    }
+    const pipeMatch = text.match(/\|\s*([a-zA-Z0-9]+)/);
+    if (pipeMatch) return pipeMatch[1];
 
-    // Handle pipe syntax
-    const pipeMatch = text.match(/\|\s*(\w+)/);
-    if (pipeMatch) {
-      return pipeMatch[1];
-    }
-
-    return text;
+    return text.trim();
   }
 
-  private extractSelectorsFromText(text: string): string[] {
-    const selectors: string[] = [];
+  private findPartialMatches(searchTerm: string): Array<AngularElementData & {selector: string}> {
+    if (!this.indexer) return [];
+    const matches: Array<AngularElementData & {selector: string}> = [];
+    const lowerSearchTerm = searchTerm.toLowerCase();
 
-    // Extract HTML tag selectors
-    const tagRegex = /<([a-zA-Z][a-zA-Z0-9-]*)/g;
-    let tagMatch;
-    while ((tagMatch = tagRegex.exec(text)) !== null) {
-      selectors.push(tagMatch[1]);
-    }
-
-    // Extract pipe selectors
-    const pipeRegex = /\|\s*([a-zA-Z][a-zA-Z0-9]*)/g;
-    let pipeMatch;
-    while ((pipeMatch = pipeRegex.exec(text)) !== null) {
-      selectors.push(pipeMatch[1]);
-    }
-
-    return [...new Set(selectors)]; // Remove duplicates
-  }
-
-  private findPartialMatches(selector: string): Array<{selector: string} & AngularElementData> {
-    if (!angularIndexer) {
-      return [];
-    }
-
-    const matches: Array<{selector: string} & AngularElementData> = [];
-    const lowerSelector = selector.toLowerCase();
-
-    for (const availableSelector of angularIndexer.getAllSelectors()) {
-      if (availableSelector.toLowerCase().includes(lowerSelector) ||
-          lowerSelector.includes(availableSelector.toLowerCase())) {
-        const element = angularIndexer.getElement(availableSelector);
-        if (element) {
-          matches.push({
-            selector: availableSelector,
-            ...element
-          });
+    for (const indexedSelector of this.indexer.getAllSelectors()) {
+      const element = this.indexer.getElement(indexedSelector);
+      if (element) {
+        if (indexedSelector.toLowerCase().includes(lowerSearchTerm) ||
+            lowerSearchTerm.includes(indexedSelector.toLowerCase())) {
+          matches.push({ ...element, selector: indexedSelector }); // Store the element and its actual selector
         }
       }
     }
-
-    return matches.slice(0, 5); // Limit to 5 suggestions
+    return matches.sort((a,b) => a.selector.length - b.selector.length).slice(0, 5);
   }
 
+  // Corrected signature and implementation
   private createCodeAction(
-      element: AngularElementData,
-      selector: string,
+      element: AngularElementData,             // The data for the Angular element
+      elementActualSelector: string,         // The actual selector string of this 'element' from the index
+      originalTermFromDiagnostic: string,    // The term extracted from the diagnostic/user input that we searched for
       diagnostic?: vscode.Diagnostic
   ): vscode.CodeAction | null {
-    const elementType = element.type;
-    const actionTitle = `Import ${element.name} (${elementType}) from ${element.path}`;
-
-    const action = new vscode.CodeAction(
-        actionTitle,
-        vscode.CodeActionKind.QuickFix
-    );
+    const actionTitle = `Import ${element.name} (${element.type}) [${elementActualSelector}]`;
+    const action = new vscode.CodeAction(actionTitle, vscode.CodeActionKind.QuickFix);
 
     action.command = {
-      title: `Import ${elementType}`,
+      title: `Import ${element.type} ${element.name}`,
       command: 'angular-auto-import.importElement',
-      arguments: [selector]
+      arguments: [elementActualSelector] // Use the element's actual selector for the import command
     };
 
     if (diagnostic) {
       action.diagnostics = [diagnostic];
     }
 
-    // Set action priority (higher number = higher priority)
-    action.isPreferred = element.type === 'component';
+    // An action is "preferred" if it's for a component AND
+    // its actual selector exactly matches the term extracted from the diagnostic.
+    action.isPreferred = (element.type === 'component' && elementActualSelector === originalTermFromDiagnostic);
 
     return action;
   }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+// import * as myExtension from '../../extension';
+
+suite('Extension Test Suite', () => {
+	vscode.window.showInformationMessage('Start all tests.');
+
+	test('Sample test', () => {
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,15 +1,319 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+// Assuming extension.ts exports the necessary classes and functions
+// Adjust the path as per your project structure.
+// This might require you to export these from your main extension.ts if not already.
+import { AngularIndexer, AngularElementData, TsConfigHelper, activate, deactivate } from '../../src/extension'; 
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+// Helper function to recursively delete a directory
+function deleteDirectoryRecursive(directoryPath: string) {
+    if (fs.existsSync(directoryPath)) {
+        fs.readdirSync(directoryPath).forEach((file) => {
+            const curPath = path.join(directoryPath, file);
+            if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                deleteDirectoryRecursive(curPath);
+            } else { // delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(directoryPath);
+    }
+}
+
+
+suite('Angular Library Indexing and Importing Test Suite', () => {
+    let testWorkspaceRoot: string;
+    let testProjectPath: string;
+    let angularIndexerInstance: AngularIndexer;
+    let mockContext: vscode.ExtensionContext;
+
+    const mockLibName = 'my-mock-lib';
+    const mockLibPathSuffix = path.join('node_modules', mockLibName);
+
+    const mockComponentDtsContent = `
+        import * as i0 from '@angular/core';
+        export declare class MockComponentOne { static ɵcmp: i0.ɵɵComponentDeclaration<MockComponentOne, "mock-comp-one", never, {}, {}, never, never, false, never>; }
+    `;
+    const mockDirectiveDtsContent = `
+        import * as i0 from '@angular/core';
+        export declare class MockDirectiveOne { static ɵdir: i0.ɵɵDirectiveDeclaration<MockDirectiveOne, "[mockDirOne]", never, {}, {}, never, never, false, never>; }
+    `;
+    const mockPipeDtsContent = `
+        import * as i0 from '@angular/core';
+        export declare class MockPipeOne { static ɵpipe: i0.ɵɵPipeDeclaration<MockPipeOne, "mockPipeOne", false>; }
+    `;
+
+    const projectPackageJsonContent = JSON.stringify({
+        name: "my-test-project",
+        dependencies: {
+            [mockLibName]: "1.0.0"
+        }
+    });
+    const libPackageJsonContent = JSON.stringify({
+        name: mockLibName,
+        version: "1.0.0",
+        main: "index.js", // Can be dummy
+        typings: "component1.d.ts" // Hint for indexer
+    });
+
+    const tsconfigJsonContent = JSON.stringify({
+        compilerOptions: {
+            baseUrl: ".",
+            paths: { "@app/*": ["src/app/*"] }
+        }
+    });
+
+    const targetComponentContent = `
+        import { Component } from '@angular/core';
+
+        @Component({
+            selector: 'app-root',
+            template: ''
+        })
+        export class AppComponent {}
+    `;
+
+    before(async () => {
+        console.log('Setting up test workspace...');
+        testWorkspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'angular-auto-import-test-'));
+        testProjectPath = path.join(testWorkspaceRoot, 'my-test-project');
+        
+        // Create project structure
+        fs.mkdirSync(testProjectPath, { recursive: true });
+        fs.mkdirSync(path.join(testProjectPath, 'src', 'app'), { recursive: true });
+        fs.mkdirSync(path.join(testProjectPath, mockLibPathSuffix), { recursive: true });
+
+        // Create files
+        fs.writeFileSync(path.join(testProjectPath, 'package.json'), projectPackageJsonContent);
+        fs.writeFileSync(path.join(testProjectPath, 'tsconfig.json'), tsconfigJsonContent);
+        fs.writeFileSync(path.join(testProjectPath, 'src', 'app', 'app.component.ts'), targetComponentContent);
+
+        // Create mock library files
+        fs.writeFileSync(path.join(testProjectPath, mockLibPathSuffix, 'package.json'), libPackageJsonContent);
+        fs.writeFileSync(path.join(testProjectPath, mockLibPathSuffix, 'component1.d.ts'), mockComponentDtsContent);
+        fs.writeFileSync(path.join(testProjectPath, mockLibPathSuffix, 'directive1.d.ts'), mockDirectiveDtsContent);
+        fs.writeFileSync(path.join(testProjectPath, mockLibPathSuffix, 'pipe1.d.ts'), mockPipeDtsContent);
+        fs.writeFileSync(path.join(testProjectPath, mockLibPathSuffix, 'index.js'), ''); // Dummy main file
+
+        // --- Mock VSCode Workspace ---
+        // Mock workspaceFolders
+        Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+            get: () => [{ uri: vscode.Uri.file(testProjectPath), name: 'my-test-project', index: 0 }]
+        });
+
+        // Mock getConfiguration
+        const originalGetConfiguration = vscode.workspace.getConfiguration;
+        Object.defineProperty(vscode.workspace, 'getConfiguration', {
+            value: (section?: string) => {
+                if (section === 'angular-auto-import') {
+                    return {
+                        get: (key: string, defaultValue?: any) => {
+                            if (key === 'projectPath') return ''; // Use workspace folder
+                            if (key === 'index.refreshInterval') return 0; // Disable periodic re-index for tests
+                            return defaultValue;
+                        },
+                        has: () => true,
+                        inspect: () => undefined,
+                        update: () => Promise.resolve()
+                    };
+                }
+                return originalGetConfiguration(section);
+            }
+        });
+        
+        // Mock ExtensionContext
+        mockContext = {
+            subscriptions: [],
+            workspaceState: {
+                get: <T>(key: string, defaultValue?: T): T | undefined => defaultValue,
+                update: (key: string, value: any) => Promise.resolve(),
+                keys: () => []
+            },
+            globalState: {
+                get: () => undefined,
+                update: () => Promise.resolve(),
+                setKeysForSync: () => {}
+            },
+            extensionPath: '',
+            storagePath: undefined,
+            globalStoragePath: '',
+            logPath: '',
+            asAbsolutePath: (relativePath: string) => path.join(testProjectPath, relativePath), // Mock as needed
+            extensionUri: vscode.Uri.file(''),
+            environmentVariableCollection: {} as any,
+            extensionMode: vscode.ExtensionMode.Test, 
+            storageUri: undefined, 
+            globalStorageUri: vscode.Uri.file(''), 
+            logUri: vscode.Uri.file('')
+        };
+
+        // Activate the extension logic to initialize the indexer
+        // This depends on how your extension is structured.
+        // We need to ensure angularIndexerInstance is the one used by the extension.
+        // For simplicity, let's assume activate sets up a global/exported indexer or we can get it.
+        // If `activate` directly returns the indexer or makes it available globally:
+        console.log('Activating extension for test...');
+        await activate(mockContext); 
+
+        // Find the indexer. This is a bit of a hack.
+        // A better way would be for `activate` to return it or for the extension to expose it for testing.
+        // For now, assuming it's implicitly created and used by commands.
+        // We might need to access it via a command or a test hook if it's not directly available.
+        // Let's try to re-fetch it by re-calling activate and grabbing it from there if it's returned (hypothetically)
+        // Or, if activate uses a global, we assume it's set.
+        // For this test, we'll assume `activate` makes the indexer available or we can create one for testing.
+        // Looking at `extension.ts`, `angularIndexer` is a top-level variable.
+        // This means we need a way to access *that specific instance*.
+        // The easiest way is to ensure the test environment can import it or the activate function returns it.
+        // Let's assume `activate` uses the module-level `angularIndexer`.
+
+        // Manually get the indexer instance as it's created in activate
+        // This is tricky because the `angularIndexer` variable is module-scoped in extension.ts
+        // A common pattern is to have a function like `getIndexer()` exported from extension.ts for testing.
+        // For now, we'll create a new one and re-run its setup logic that `activate` would do.
+        // This is not ideal as it tests a separate instance, but is simpler without modifying extension code.
+        
+        // angularIndexerInstance = new AngularIndexer();
+        // await angularIndexerInstance.setProjectRoot(testProjectPath);
+        // await angularIndexerInstance.generateFullIndex(testProjectPath, mockContext);
+
+        // To get the actual indexer used by the extension, we need to ensure activate has run
+        // and that the `angularIndexer` variable in `extension.ts` is populated.
+        // Then, we need a way to *get* that instance.
+        // If `extension.ts` exports `getAngularIndexer()`:
+        // angularIndexerInstance = getAngularIndexer(); // Hypothetical
+        // For now, we'll rely on the fact that `activate` has run and populated its internal indexer.
+        // And for `importElementToFile`, it uses the global `currentProjectPath` and `getGlobalTsConfig`
+        // which are set by `activate`. The `AngularElementData` comes from our test.
+
+        // Re-trigger indexing to ensure the instance used by commands is populated
+        // This is a common approach if the indexer isn't directly exposed
+        await vscode.commands.executeCommand('angular-auto-import.reindex');
+        console.log('Test workspace setup complete.');
+
+        // A short delay to allow file watchers and async operations to settle, if any
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    });
+
+    after(() => {
+        console.log('Cleaning up test workspace...');
+        deactivate(); // Call deactivate to clean up watchers etc.
+        deleteDirectoryRecursive(testWorkspaceRoot);
+        // Restore original vscode.workspace.getConfiguration if changed
+        Object.defineProperty(vscode.workspace, 'getConfiguration', {
+             get: () => vscode.workspace.getConfiguration // simplified restoration
+        });
+         Object.defineProperty(vscode.workspace, 'workspaceFolders', { // Restore
+            get: () => []
+        });
+        console.log('Test workspace cleanup complete.');
+    });
+
+    suite('Library Element Indexing', () => {
+        test('should index elements from the mock library', async () => {
+            // The indexer should have been populated by the reindex command in beforeAll
+            // We need a way to get the indexer instance that the command used.
+            // This is the hardest part of testing vscode extensions not designed for easy testability.
+            
+            // For this test, let's assume we need to create our own indexer instance
+            // and test its logic directly, which is more of a unit test for the indexer.
+            const indexer = new AngularIndexer();
+            indexer.setProjectRoot(testProjectPath); // Crucial
+            await indexer.generateFullIndex(testProjectPath, mockContext);
+
+            const componentEl = indexer.getElement('mock-comp-one');
+            assert.ok(componentEl, 'Component "mock-comp-one" should be indexed');
+            assert.strictEqual(componentEl.name, 'MockComponentOne', 'Component name should be MockComponentOne');
+            assert.strictEqual(componentEl.type, 'component', 'Element type should be component');
+            assert.strictEqual(componentEl.isLibraryElement, true, 'Component should be marked as library element');
+            assert.ok(componentEl.path.includes(path.join(mockLibPathSuffix, 'component1.d.ts')), 'Component path should be correct');
+            
+            const directiveEl = indexer.getElement('[mockDirOne]');
+            assert.ok(directiveEl, 'Directive "[mockDirOne]" should be indexed');
+            assert.strictEqual(directiveEl.name, 'MockDirectiveOne', 'Directive name should be MockDirectiveOne');
+            assert.strictEqual(directiveEl.type, 'directive', 'Element type should be directive');
+            assert.strictEqual(directiveEl.isLibraryElement, true, 'Directive should be marked as library element');
+            assert.ok(directiveEl.path.includes(path.join(mockLibPathSuffix, 'directive1.d.ts')), 'Directive path should be correct');
+
+            const pipeEl = indexer.getElement('mockPipeOne');
+            assert.ok(pipeEl, 'Pipe "mockPipeOne" should be indexed');
+            assert.strictEqual(pipeEl.name, 'MockPipeOne', 'Pipe name should be MockPipeOne');
+            assert.strictEqual(pipeEl.type, 'pipe', 'Element type should be pipe');
+            assert.strictEqual(pipeEl.isLibraryElement, true, 'Pipe should be marked as library element');
+            assert.ok(pipeEl.path.includes(path.join(mockLibPathSuffix, 'pipe1.d.ts')), 'Pipe path should be correct');
+        });
+    });
+
+    suite('Library Import Statement Generation', () => {
+        test('should generate correct import for a library component', async () => {
+            // Again, using a local indexer instance for predictability in this test
+            const indexer = new AngularIndexer();
+            indexer.setProjectRoot(testProjectPath);
+            await indexer.generateFullIndex(testProjectPath, mockContext);
+            
+            const componentData = indexer.getElement('mock-comp-one');
+            assert.ok(componentData, 'Test setup: mock-comp-one should be in index');
+
+            const targetComponentPath = path.join(testProjectPath, 'src', 'app', 'app.component.ts');
+            
+            // Need to ensure `importElementToFile` is exported or testable.
+            // Let's assume it is, or we call the command that uses it.
+            // For this example, let's assume we can call a testable version or the command.
+
+            // To test importElementToFile, we need `currentProjectPath` and `getGlobalTsConfig` to be set.
+            // `activate` should have handled this. We are calling the command which should use these.
+            
+            // Simulate the command:
+            // 1. Get element data (done above)
+            // 2. Mock activeTextEditor to point to targetComponentPath
+            const originalActiveEditor = vscode.window.activeTextEditor;
+            const mockEditor = {
+                document: await vscode.workspace.openTextDocument(targetComponentPath)
+            };
+            Object.defineProperty(vscode.window, 'activeTextEditor', {
+                get: () => mockEditor,
+                configurable: true 
+            });
+            
+            // Execute the import command - this uses the extension's own indexer
+            await vscode.commands.executeCommand('angular-auto-import.importElement', 'mock-comp-one');
+            
+            // Restore activeTextEditor
+            Object.defineProperty(vscode.window, 'activeTextEditor', {
+                get: () => originalActiveEditor,
+                configurable: true
+            });
+
+            const updatedContent = fs.readFileSync(targetComponentPath, 'utf-8');
+            assert.ok(
+                updatedContent.includes(`import { MockComponentOne } from '${mockLibName}';`),
+                `Import statement for MockComponentOne from '${mockLibName}' not found. Content: \n${updatedContent}`
+            );
+        });
+    });
 });
+
+// Helper to ensure extension exports are available for testing
+// This would be in your actual extension.ts
+/*
+export {
+    AngularIndexer, // if you want to test it directly
+    AngularElementData,
+    importElementToFile, // if you want to test it directly
+    activate,
+    deactivate,
+    getAngularIndexer, // A function to get the main indexer instance
+    getGlobalTsConfig,
+    getGlobalProjectPath
+};
+*/
+// And your main extension.ts would have:
+// let angularIndexer: AngularIndexer;
+// export function getAngularIndexer() { return angularIndexer; }
+// export function getGlobalTsConfig() { return currentTsConfig; }
+// export function getGlobalProjectPath() { return currentProjectPath; }
+// ... and ensure `angularIndexer` is assigned in `activate`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"module": "Node16",
+		"target": "ES2022",
+		"lib": [
+			"ES2022"
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"strict": true,   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	}
+}

--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -1,0 +1,48 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your extension and command.
+  * The sample plugin registers a command and defines its title and command name. With this information VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
+* `src/extension.ts` - this is the main file where you will provide the implementation of your command.
+  * The file exports one function, `activate`, which is called the very first time your extension is activated (in this case by executing the command). Inside the `activate` function we call `registerCommand`.
+  * We pass the function containing the implementation of the command as the second parameter to `registerCommand`.
+
+## Setup
+
+* install the recommended extensions (amodio.tsl-problem-matcher, ms-vscode.extension-test-runner, and dbaeumer.vscode-eslint)
+
+
+## Get up and running straight away
+
+* Press `F5` to open a new window with your extension loaded.
+* Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
+* Set breakpoints in your code inside `src/extension.ts` to debug your extension.
+* Find output from your extension in the debug console.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+
+## Explore the API
+
+* You can open the full set of our API when you open the file `node_modules/@types/vscode/index.d.ts`.
+
+## Run tests
+
+* Install the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner)
+* Run the "watch" task via the **Tasks: Run Task** command. Make sure this is running, or tests might not be discovered.
+* Open the Testing view from the activity bar and click the Run Test" button, or use the hotkey `Ctrl/Cmd + ; A`
+* See the output of the test result in the Test Results view.
+* Make changes to `src/test/extension.test.ts` or create new test files inside the `test` folder.
+  * The provided test runner will only consider files matching the name pattern `**.test.ts`.
+  * You can create folders inside the `test` folder to structure your tests any way you want.
+
+## Go further
+
+* Reduce the extension size and improve the startup time by [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).
+* [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VS Code extension marketplace.
+* Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).


### PR DESCRIPTION


I've implemented support for suggesting and auto-importing individual
built-in Angular directives (e.g., NgIf, NgForOf, NgOptimizedImage)
and pipes (e.g., AsyncPipe, DatePipe) directly into standalone
components.

Key changes:
- I created `src/angular-builtins.ts` with a predefined list of common
  standalone built-in elements and their source packages (e.g., NgIf
  from @angular/common).
- I enhanced `QuickfixImportProvider` and the HTML completion provider to
  recognize these elements in standalone component templates.
- I implemented `importStandaloneBuiltInElement` and a helper
  `addSymbolToComponentImportsArray` to:
  1. Add the specific ES6 import (e.g., `import { NgIf } from '@angular/common';`).
  2. Add the element's class name (e.g., `NgIf`) to the standalone
     component's `@Component.imports` array.
- I added comprehensive tests verifying the import of directives and
  pipes into standalone components, including updates to the
  `@Component.imports` array under various conditions.
- I updated `README.md` to document this new feature, highlighting its
  alignment with modern Angular best practices for standalone components.